### PR TITLE
switch file.rename to file.copy

### DIFF
--- a/R/zzz.r
+++ b/R/zzz.r
@@ -266,7 +266,7 @@ write_geojson <- function(input, file = "myfile.geojson", ...){
 write_ogr <- function(input, dir, file, ...){
   input@data <- convert_ordered(input@data)
   writeOGR(input, dir, "", "GeoJSON", ...)
-  file.rename(dir, file)
+  file.copy(dir, file)
   message("Success! File is at ", file)
 }
 


### PR DESCRIPTION
Addresses issue #50 to eliminate 'Invalid cross-device link' errors when output from geojson_write() crosses file systems.