### PR TITLE
Add proj4 info to geojson_sp docs

### DIFF
--- a/R/construction.R
+++ b/R/construction.R
@@ -59,7 +59,7 @@ add_geolist <- function(t1, t2, t2name) {
   if (!xor(!is(t2, "geo_list"), !is(t2, "json"))) {
     stop("Don't know how to add ", t2name, " to a geo_list object", call. = FALSE)
   }
-  if (class(t2) == "geo_list") { 
+  if (is(t2, "geo_list")) { 
     t1$features <- c(t1$features, t2$features)
     att1 <- attr(t1, "from")
     att2 <- attr(t2, "from")
@@ -75,7 +75,7 @@ add_json <- function(t1, t2, t2name) {
   if (!xor(!is(t2, "json"), !is(t2, "geo_list"))) {
     stop("Don't know how to add ", t2name, " to a json object", call. = FALSE)
   }
-  if (class(t2) == "geo_list") { 
+  if (is(t2, "geo_list")) { 
     jsonlite::toJSON(list(type = "FeatureCollection", 
         features = c(geojson_list(t1)$features, geojson_list(t2)$features)
     ), auto_unbox = TRUE)

--- a/R/geojson_sp.R
+++ b/R/geojson_sp.R
@@ -13,6 +13,10 @@
 #' \code{SpatialPolygonsDataFrame} class, etc., depending on what the 
 #' structure of the GeoJSON. 
 #' 
+#' The reading and writing of the CRS to/from geojson is inconsistent. You can 
+#' directly set the CRS by passing a valid PROJ4 string to the \code{p4s} argument in 
+#' \code{\link[rgdal]{readOGR}}.
+#' 
 #' @examples \dontrun{
 #' # geo_list ------------------
 #' ## From a numeric vector of length 2 to a point
@@ -39,6 +43,9 @@
 #' # from featurecollectino of points
 #' geojson_json(us_cities[1:2,], lat='lat', lon='long') %>% geojson_sp
 #' geojson_json(us_cities[1:2,], lat='lat', lon='long') %>% geojson_sp %>% plot
+#' 
+#' # Set the CRS via the p4s argument
+#' geojson_json(us_cities[1:2,], lat='lat', lon='long') %>% geojson_sp(p4s = "+init=epsg:4326")
 #' }
 geojson_sp <- function(x, disambiguateFIDs = TRUE, ...) {
   UseMethod("geojson_sp")

--- a/man/geojson_sp.Rd
+++ b/man/geojson_sp.Rd
@@ -25,7 +25,11 @@ Convert output of geojson_list or geojson_json to spatial classes
 The spatial class object returned will depend on the input GeoJSON. 
 Sometimes you will get back a \code{SpatialPoints} class, and sometimes a 
 \code{SpatialPolygonsDataFrame} class, etc., depending on what the 
-structure of the GeoJSON.
+structure of the GeoJSON. 
+
+The reading and writing of the CRS to/from geojson is inconsistent. You can 
+directly set the CRS by passing a valid PROJ4 string to the \code{p4s} argument in 
+\code{\link[rgdal]{readOGR}}.
 }
 \examples{
 \dontrun{
@@ -54,6 +58,9 @@ geojson_json(c(-99.74,32.45)) \%>\% geojson_sp \%>\% plot
 # from featurecollectino of points
 geojson_json(us_cities[1:2,], lat='lat', lon='long') \%>\% geojson_sp
 geojson_json(us_cities[1:2,], lat='lat', lon='long') \%>\% geojson_sp \%>\% plot
+
+# Set the CRS via the p4s argument
+geojson_json(us_cities[1:2,], lat='lat', lon='long') \%>\% geojson_sp(p4s = "+init=epsg:4326")
 }
 }
 


### PR DESCRIPTION
I also changed a couple of instances of class checking that were generating warnings in the tests due to objects belonging to more than one class (`geo_list`). Used `is(obj, "geo_list")` instead of `class == "geo_list"`.