### PR TITLE
Use _pipe from io.h on Windows

### DIFF
--- a/src/captured_write_ogr.cpp
+++ b/src/captured_write_ogr.cpp
@@ -3,6 +3,8 @@
 #include <stdlib.h>
 #ifdef _WIN32
   #include <io.h>
+#else
+  #include <unistd.h>
 #endif
 
 using namespace Rcpp;

--- a/src/captured_write_ogr.cpp
+++ b/src/captured_write_ogr.cpp
@@ -1,7 +1,9 @@
 #include <Rcpp.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
+#ifdef _WIN32
+  #include <io.h>
+#endif
 
 using namespace Rcpp;
 
@@ -50,8 +52,11 @@ CharacterVector capturedWriteOGR(SEXP obj,
   
   // ok, there's some error checking if we couldn't even
   // get the hack started
-  
-  if (pipe(out_pipe) != 0 ) { return(NA_STRING); }
+  #ifdef _WIN32
+    if (_pipe(out_pipe, MAX_LEN, 0) != 0 ) { return(NA_STRING); }
+  #else
+    if (pipe(out_pipe) != 0 ) { return(NA_STRING); }
+  #endif
   
   dup2(out_pipe[1], STDOUT_FILENO);
   close(out_pipe[1]);


### PR DESCRIPTION
My attempt at getting this to work on Windows. It appears to work with the very simple example:

```r
cities <- readOGR(system.file("vectors", package = "rgdal")[1], "cities")
geojsonio:::capturedWriteOGR(cities, object.size(cities), "cities", writeOGR)
```

I'm sure there's a more elegant way to do this, and will definitely warrant testing on a non-Windows machine to make sure I didn't break that part :)