### PR TITLE
Require rgdal >= 1.1-1 for writeOGR multipolygon bugfix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     stats,
     utils,
     sp,
-    rgdal,
+    rgdal (>= 1.1-1),
     rgeos,
     httr (>= 1.1.0),
     maptools,

--- a/R/startup.R
+++ b/R/startup.R
@@ -1,3 +1,0 @@
-.onAttach <- function(libname, pkgname) {
-  packageStartupMessage("\nWe recommend using rgdal v1.1-1 or greater, but we don't require it\nrgdal::writeOGR in previous versions didn't write\nmultipolygon objects to geojson correctly.\nSee https://stat.ethz.ch/pipermail/r-sig-geo/2015-October/023609.html")
-}


### PR DESCRIPTION
See #69.

Now that `rgdal` binaries are [up to date on CRAN](https://cran.r-project.org/web/packages/rgdal/index.html) for all platforms, I suggest we impose the `rgdal` dependency version requirement. CRAN version is `1.1-10`, but the multipolygon bug was fixed in `1.1-1`, so that's what I went with.

I also removed the package startup message.