### PR TITLE
Add option to convert to WGS84

### DIFF
--- a/R/crs_convert.R
+++ b/R/crs_convert.R
@@ -37,7 +37,7 @@ convert_crs_sf_sfc <- function(x, crs) {
   if (!requireNamespace("sf", quietly = TRUE)) {
     stop("You don't have the 'sf' package installed. Please install and try again")
   } else {
-    message("Converting CRS from EPSG:", st_crs(x)[["epsg"]], " to WGS84.")
+    message("Converting CRS from EPSG:", sf::st_crs(x)[["epsg"]], " to WGS84.")
     x <- sf::st_transform(x, 4326)
   }
 }

--- a/R/crs_convert.R
+++ b/R/crs_convert.R
@@ -51,7 +51,7 @@ is_wgs84_sf_attr <- function(crs_attr, warn) {
   } else {
     is_it <- epsg == 4326
   }
-  is_it <- is_it || is.na(is_it) # Give NA epsg the benefit of the doubt
+  is_it <- is.na(is_it) || is_it # Give NA epsg the benefit of the doubt
   if (!is_it && warn) {
     warning("Input CRS is not WGS84 (epsg:4326), the standard for GeoJSON")
   }
@@ -61,11 +61,11 @@ is_wgs84_sf_attr <- function(crs_attr, warn) {
 is_wgs84.Spatial <- function(x, warn = TRUE) {
   prj4 <- proj4string(x)
   epsg <- epsg_from_proj4(prj4)
-  if (epsg == 4326) {
-    is_it <- TRUE
-  } else if (is.na(epsg)) {
+  if (is.na(epsg)) {
     is_it <- is_wgs84_proj4(prj4)
-    is_it <- is_it || is.na(is_it)
+    is_it <- is.na(is_it) || is_it
+  } else if (epsg == 4326) {
+    is_it <- TRUE
   } else {
     is_it <- FALSE
   }

--- a/R/crs_convert.R
+++ b/R/crs_convert.R
@@ -24,7 +24,7 @@ detect_conver_crs_sf_sfc <- function(x) {
     if (!requireNamespace("sf", quietly = TRUE)) {
       stop("Your input is not in a WGS84 and you don't have the 'sf' package installed. Please install and try again")
     } else {
-      message("Converting CRS from EPSG:", st_crs(x), " to WGS84.")
+      message("Converting CRS from EPSG:", st_crs(x)[["epsg"]], " to WGS84.")
       x <- sf::st_transform(x, 4326)
     }
   }

--- a/R/crs_convert.R
+++ b/R/crs_convert.R
@@ -1,0 +1,90 @@
+detect_convert_crs <- function(x) {
+  UseMethod("detect_convert_crs")
+}
+
+detect_convert_crs.sf <- function(x) {
+  detect_conver_crs_sf_sfc(x)
+}
+
+detect_convert_crs.sfc <- function(x) {
+  detect_conver_crs_sf_sfc(x)
+}
+
+detect_convert_crs.Spatial <- function(x) {
+  if (!is_wgs84(x, warn = FALSE)) {
+    message("Converting CRS from EPSG:", 
+            epsg_from_proj4(proj4string(x)), " to WGS84.")
+    x <- sp::spTransform(x, CRS("+init=epsg:4326"))
+  }
+  x
+}
+
+detect_conver_crs_sf_sfc <- function(x) {
+  if (!is_wgs84(x, warn = FALSE)) {
+    if (!requireNamespace("sf", quietly = TRUE)) {
+      stop("Your input is not in a WGS84 and you don't have the 'sf' package installed. Please install and try again")
+    } else {
+      message("Converting CRS from EPSG:", st_crs(x), " to WGS84.")
+      x <- sf::st_transform(x, 4326)
+    }
+  }
+  x
+}
+
+is_wgs84 <- function(x, warn = TRUE) UseMethod("is_wgs84")
+
+is_wgs84.sf <- function(x, warn = TRUE) {
+  geom_col <- get_sf_column_name(x)
+  crs_attr <- attr((x[[geom_col]]), "crs")
+  is_wgs84_sf_attr(crs_attr, warn = warn)
+}
+
+is_wgs84.sfc <- function(x, warn = TRUE) {
+  crs_attr <- attr(x, "crs")
+  is_wgs84_sf_attr(crs_attr, warn = warn)
+}
+
+is_wgs84_sf_attr <- function(crs_attr, warn) {
+  epsg <- crs_attr[["epsg"]]
+  if (is.na(epsg)) {
+    is_it <- is_wgs84_proj4(crs_attr[["proj4string"]])
+  } else {
+    is_it <- epsg == 4326
+  }
+  is_it <- is_it || is.na(is_it) # Give NA epsg the benefit of the doubt
+  if (!is_it && warn) {
+    warning("Input CRS is not WGS84 (epsg:4326), the standard for GeoJSON")
+  }
+  is_it
+}
+
+is_wgs84.Spatial <- function(x, warn = TRUE) {
+  prj4 <- proj4string(x)
+  epsg <- epsg_from_proj4(prj4)
+  if (epsg == 4326) {
+    is_it <- TRUE
+  } else if (is.na(epsg)) {
+    is_it <- is_wgs84_proj4(prj4)
+    is_it <- is_it || is.na(is_it)
+  } else {
+    is_it <- FALSE
+  }
+  if (!is_it && warn) {
+    warning("Input CRS is not WGS84 (epsg:4326), the standard for GeoJSON")
+  }
+  is_it
+}
+
+epsg_from_proj4 <- function(prj4) {
+  if (grepl("init=epsg", prj4)) {
+    ret <- as.integer(gsub("(.*\\init=epsg:)([0-9]{4,5})(.*$)", "\\2", prj4))
+  } else {
+    ret <- NA_integer_
+  }
+  ret
+}
+
+is_wgs84_proj4 <- function(prj4) {
+  if (is.na(prj4)) return(NA_character_)
+  grepl("datum=WGS84", prj4) && grepl("proj=longlat", prj4)
+}

--- a/R/crs_convert.R
+++ b/R/crs_convert.R
@@ -15,7 +15,8 @@ convert_crs.Spatial <- function(x, crs = NULL) {
   
   if (is.na(is_it)) {
     if (!is.null(crs)) {
-      sp::proj4string(x) <- CRS(crs)
+      if (is.numeric(crs)) crs <- paste0("+init=epsg:",crs)
+      sp::proj4string(x) <- sp::CRS(crs)
     }
   } else if (is_it) {
     return(x)

--- a/R/crs_convert.R
+++ b/R/crs_convert.R
@@ -1,21 +1,21 @@
-convert_crs <- function(x, init_crs = NULL) {
+convert_crs <- function(x, crs = NULL) {
   UseMethod("convert_crs")
 }
 
-convert_crs.sf <- function(x, init_crs = NULL) {
-  convert_crs_sf_sfc(x, init_crs = init_crs)
+convert_crs.sf <- function(x, crs = NULL) {
+  convert_crs_sf_sfc(x, crs = crs)
 }
 
-convert_crs.sfc <- function(x, init_crs = NULL) {
-  convert_crs_sf_sfc(x, init_crs = init_crs)
+convert_crs.sfc <- function(x, crs = NULL) {
+  convert_crs_sf_sfc(x, crs = crs)
 }
 
-convert_crs.Spatial <- function(x, init_crs = NULL) {
+convert_crs.Spatial <- function(x, crs = NULL) {
   is_it <- is_wgs84(x, warn = FALSE)
   
   if (is.na(is_it)) {
-    if (!is.null(init_crs)) {
-      sp::proj4string(x) <- CRS(init_crs)
+    if (!is.null(crs)) {
+      sp::proj4string(x) <- CRS(crs)
     }
   } else if (is_it) {
     return(x)
@@ -24,12 +24,12 @@ convert_crs.Spatial <- function(x, init_crs = NULL) {
   sp::spTransform(x, CRS("+init=epsg:4326"))
 }
 
-convert_crs_sf_sfc <- function(x, init_crs) {
+convert_crs_sf_sfc <- function(x, crs) {
   is_it <- is_wgs84(x, warn = FALSE)
   
   if (is.na(is_it)) {
-    if (!is.null(init_crs)) {
-      sf::st_crs(x) <- init_crs
+    if (!is.null(crs)) {
+      sf::st_crs(x) <- crs
     }
   } else if (is_it) {
     return(x)

--- a/R/crs_convert.R
+++ b/R/crs_convert.R
@@ -1,58 +1,63 @@
-detect_convert_crs <- function(x) {
-  UseMethod("detect_convert_crs")
+convert_crs <- function(x, init_crs = NULL) {
+  UseMethod("convert_crs")
 }
 
-detect_convert_crs.sf <- function(x) {
-  detect_conver_crs_sf_sfc(x)
+convert_crs.sf <- function(x, init_crs = NULL) {
+  convert_crs_sf_sfc(x, init_crs = init_crs)
 }
 
-detect_convert_crs.sfc <- function(x) {
-  detect_conver_crs_sf_sfc(x)
+convert_crs.sfc <- function(x, init_crs = NULL) {
+  convert_crs_sf_sfc(x, init_crs = init_crs)
 }
 
-detect_convert_crs.Spatial <- function(x) {
-  if (!is_wgs84(x, warn = FALSE)) {
-    message("Converting CRS from EPSG:", 
-            epsg_from_proj4(proj4string(x)), " to WGS84.")
-    x <- sp::spTransform(x, CRS("+init=epsg:4326"))
-  }
-  x
-}
-
-detect_conver_crs_sf_sfc <- function(x) {
-  if (!is_wgs84(x, warn = FALSE)) {
-    if (!requireNamespace("sf", quietly = TRUE)) {
-      stop("Your input is not in a WGS84 and you don't have the 'sf' package installed. Please install and try again")
-    } else {
-      message("Converting CRS from EPSG:", st_crs(x)[["epsg"]], " to WGS84.")
-      x <- sf::st_transform(x, 4326)
+convert_crs.Spatial <- function(x, init_crs = NULL) {
+  is_it <- is_wgs84(x, warn = FALSE)
+  
+  if (is.na(is_it)) {
+    if (!is.null(init_crs)) {
+      sp::proj4string(x) <- CRS(init_crs)
     }
+  } else if (is_it) {
+    return(x)
   }
-  x
+  message("Converting CRS from '", proj4string(x), "' to WGS84.")
+  sp::spTransform(x, CRS("+init=epsg:4326"))
+}
+
+convert_crs_sf_sfc <- function(x, init_crs) {
+  is_it <- is_wgs84(x, warn = FALSE)
+  
+  if (is.na(is_it)) {
+    if (!is.null(init_crs)) {
+      sf::st_crs(x) <- init_crs
+    }
+  } else if (is_it) {
+    return(x)
+  }
+  if (!requireNamespace("sf", quietly = TRUE)) {
+    stop("You don't have the 'sf' package installed. Please install and try again")
+  } else {
+    message("Converting CRS from EPSG:", st_crs(x)[["epsg"]], " to WGS84.")
+    x <- sf::st_transform(x, 4326)
+  }
 }
 
 is_wgs84 <- function(x, warn = TRUE) UseMethod("is_wgs84")
 
 is_wgs84.sf <- function(x, warn = TRUE) {
   geom_col <- get_sf_column_name(x)
-  crs_attr <- attr((x[[geom_col]]), "crs")
-  is_wgs84_sf_attr(crs_attr, warn = warn)
+  is_wgs84(x[[geom_col]], warn = warn)
 }
 
 is_wgs84.sfc <- function(x, warn = TRUE) {
   crs_attr <- attr(x, "crs")
-  is_wgs84_sf_attr(crs_attr, warn = warn)
-}
-
-is_wgs84_sf_attr <- function(crs_attr, warn) {
   epsg <- crs_attr[["epsg"]]
   if (is.na(epsg)) {
     is_it <- is_wgs84_proj4(crs_attr[["proj4string"]])
   } else {
     is_it <- epsg == 4326
   }
-  is_it <- is.na(is_it) || is_it # Give NA epsg the benefit of the doubt
-  if (!is_it && warn) {
+  if (!is.na(is_it) && !is_it && warn) {
     warning("Input CRS is not WGS84 (epsg:4326), the standard for GeoJSON")
   }
   is_it
@@ -60,31 +65,16 @@ is_wgs84_sf_attr <- function(crs_attr, warn) {
 
 is_wgs84.Spatial <- function(x, warn = TRUE) {
   prj4 <- proj4string(x)
-  epsg <- epsg_from_proj4(prj4)
-  if (is.na(epsg)) {
-    is_it <- is_wgs84_proj4(prj4)
-    is_it <- is.na(is_it) || is_it
-  } else if (epsg == 4326) {
-    is_it <- TRUE
-  } else {
-    is_it <- FALSE
-  }
-  if (!is_it && warn) {
+  is_it <- is_wgs84_proj4(prj4)
+  if (!is.na(is_it) && !is_it && warn) {
     warning("Input CRS is not WGS84 (epsg:4326), the standard for GeoJSON")
   }
   is_it
 }
 
-epsg_from_proj4 <- function(prj4) {
-  if (grepl("init=epsg", prj4)) {
-    ret <- as.integer(gsub("(.*\\init=epsg:)([0-9]{4,5})(.*$)", "\\2", prj4))
-  } else {
-    ret <- NA_integer_
-  }
-  ret
-}
-
 is_wgs84_proj4 <- function(prj4) {
-  if (is.na(prj4)) return(NA_character_)
-  grepl("datum=WGS84", prj4) && grepl("proj=longlat", prj4)
+  if (is.na(prj4)) return(NA)
+  if (grepl("init=epsg:4326", prj4)) return(TRUE)
+  if (grepl("datum=WGS84", prj4) && grepl("proj=longlat", prj4)) return(TRUE)
+  return(FALSE)
 }

--- a/R/crs_convert.R
+++ b/R/crs_convert.R
@@ -1,16 +1,16 @@
-convert_crs <- function(x, crs = NULL) {
-  UseMethod("convert_crs")
+convert_wgs84 <- function(x, crs = NULL) {
+  UseMethod("convert_wgs84")
 }
 
-convert_crs.sf <- function(x, crs = NULL) {
-  convert_crs_sf_sfc(x, crs = crs)
+convert_wgs84.sf <- function(x, crs = NULL) {
+  convert_wgs84_sf_sfc(x, crs = crs)
 }
 
-convert_crs.sfc <- function(x, crs = NULL) {
-  convert_crs_sf_sfc(x, crs = crs)
+convert_wgs84.sfc <- function(x, crs = NULL) {
+  convert_wgs84_sf_sfc(x, crs = crs)
 }
 
-convert_crs.Spatial <- function(x, crs = NULL) {
+convert_wgs84.Spatial <- function(x, crs = NULL) {
   is_it <- is_wgs84(x, warn = FALSE)
   
   if (is.na(is_it)) {
@@ -25,7 +25,7 @@ convert_crs.Spatial <- function(x, crs = NULL) {
   sp::spTransform(x, CRS("+init=epsg:4326"))
 }
 
-convert_crs_sf_sfc <- function(x, crs) {
+convert_wgs84_sf_sfc <- function(x, crs) {
   is_it <- is_wgs84(x, warn = FALSE)
   
   if (is.na(is_it)) {

--- a/R/geojson_json.R
+++ b/R/geojson_json.R
@@ -10,6 +10,8 @@
 #' @param type  (character)The type of collection. One of FeatureCollection (default) or GeometryCollection.
 #' @param group (character) A grouping variable to perform grouping for polygons - doesn't
 #' apply for points
+#' @param convert_crs Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.
+#' @param crs The CRS of the input if it is not already defined. For \code{sf} objects this can be an epsg code as a four or five digit integer or a valid proj4 string. For \code{Spatial} obects it must be a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.
 #' @param ... Further args passed on to \code{\link[jsonlite]{toJSON}}
 #'
 #' @return An object of class \code{geo_json} (and \code{json})
@@ -307,7 +309,8 @@ geojson_json.sfc <- function(input, lat = NULL, lon = NULL, group = NULL,
 
 #' @export
 geojson_json.sfg <- function(input, lat = NULL, lon = NULL, group = NULL,
-                             geometry = "point",  type='FeatureCollection', ...) {
+                             geometry = "point",  type='FeatureCollection',
+                             convert_crs = FALSE, crs = NULL, ...) {
   as.json(geojson_list(input))
 }
 

--- a/R/geojson_json.R
+++ b/R/geojson_json.R
@@ -207,84 +207,102 @@
 #' geojson_json(c(-99.74,32.45)) %>% pretty
 #' }
 geojson_json <- function(input, lat = NULL, lon = NULL, group = NULL,
-                         geometry = "point", type='FeatureCollection', ...) {
+                         geometry = "point", type='FeatureCollection',
+                         convert_crs = FALSE, crs = NULL, ...) {
   UseMethod("geojson_json")
 }
 
 # spatial classes from sp --------------------------
 #' @export
 geojson_json.SpatialPolygons <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                         geometry = "point",  type='FeatureCollection', ...) {
-  class_json(geojson_rw(input, target = "char"), ...)
+                                         geometry = "point",  type='FeatureCollection',
+                                         convert_crs = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
 }
 
 #' @export
-geojson_json.SpatialPolygonsDataFrame <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                                  geometry = "point",  type='FeatureCollection', ...) {
-  class_json(geojson_rw(input, target = "char"), ...)
+geojson_json.SpatialPolygonsDataFrame <- function(input, lat = NULL, lon = NULL, 
+                                                  group = NULL, geometry = "point",  
+                                                  type='FeatureCollection',
+                                                  convert_crs = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
 }
 
 #' @export
 geojson_json.SpatialPoints <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                       geometry = "point",  type='FeatureCollection', ...) {
+                                       geometry = "point",  type='FeatureCollection',
+                                       convert_crs = FALSE, crs = NULL, ...) {
   dat <- SpatialPointsDataFrame(input, data.frame(dat = 1:NROW(input@coords)))
-  class_json(geojson_rw(dat, target = "char"))
+  class_json(geojson_rw(dat, target = "char", convert_crs = convert_crs, crs = crs))
 }
 
 #' @export
-geojson_json.SpatialPointsDataFrame <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                                geometry = "point",  type='FeatureCollection', ...) {
-  class_json(geojson_rw(input, target = "char"), ...)
+geojson_json.SpatialPointsDataFrame <- function(input, lat = NULL, lon = NULL, 
+                                                group = NULL, geometry = "point",  
+                                                type='FeatureCollection',
+                                                convert_crs = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
 }
 
 #' @export
 geojson_json.SpatialLines <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                      geometry = "point",  type='FeatureCollection', ...) {
-  class_json(geojson_rw(input, target = "char"), ...)
+                                      geometry = "point",  type='FeatureCollection',
+                                      convert_crs = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
 }
 
 #' @export
-geojson_json.SpatialLinesDataFrame <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                               geometry = "point",  type='FeatureCollection', ...) {
-  class_json(geojson_rw(input, target = "char"), ...)
+geojson_json.SpatialLinesDataFrame <- function(input, lat = NULL, lon = NULL, 
+                                               group = NULL, geometry = "point",  
+                                               type='FeatureCollection',
+                                               convert_crs = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
 }
 
 #' @export
 geojson_json.SpatialGrid <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                     geometry = "point",  type='FeatureCollection', ...) {
-  class_json(geojson_rw(input, target = "char"), ...)
+                                     geometry = "point",  type='FeatureCollection',
+                                     convert_crs = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
 }
 
 #' @export
-geojson_json.SpatialGridDataFrame <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                              geometry = "point",  type='FeatureCollection', ...) {
-  class_json(geojson_rw(input, target = "char"), ...)
+geojson_json.SpatialGridDataFrame <- function(input, lat = NULL, lon = NULL, 
+                                              group = NULL, geometry = "point",  
+                                              type='FeatureCollection',
+                                              convert_crs = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
 }
 
 #' @export
 geojson_json.SpatialPixels <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                       geometry = "point",  type='FeatureCollection', ...) {
-  class_json(geojson_rw(input, target = "char"), ...)
+                                       geometry = "point",  type='FeatureCollection',
+                                       convert_crs = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
 }
 
 #' @export
-geojson_json.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                                geometry = "point",  type='FeatureCollection', ...) {
-  class_json(geojson_rw(input, target = "char"), ...)
+geojson_json.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL, 
+                                                group = NULL, geometry = "point",  
+                                                type='FeatureCollection',
+                                                convert_crs = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
 }
 
 # sf classes ---------------------------------
 
 #' @export
 geojson_json.sf <- function(input, lat = NULL, lon = NULL, group = NULL,
-                            geometry = "point",  type='FeatureCollection', ...) {
-  as.json(geojson_list(input))
+                            geometry = "point",  type='FeatureCollection',
+                            convert_crs = FALSE, crs = NULL, ...) {
+  as.json(geojson_list(input, convert_crs = convert_crs, crs = crs))
 }
 
 #' @export
 geojson_json.sfc <- function(input, lat = NULL, lon = NULL, group = NULL,
-                             geometry = "point",  type='FeatureCollection', ...) {
-  as.json(geojson_list(input))
+                             geometry = "point",  type='FeatureCollection',
+                             convert_crs = FALSE, crs = NULL, ...) {
+  as.json(geojson_list(input, convert_crs = convert_crs, crs = crs))
 }
 
 #' @export
@@ -296,20 +314,25 @@ geojson_json.sfg <- function(input, lat = NULL, lon = NULL, group = NULL,
 # spatial classes from rgeos --------------------------
 #' @export
 geojson_json.SpatialRings <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                      geometry = "point",  type='FeatureCollection', ...) {
-  class_json(geojson_rw(input, target = "char"), ...)
+                                      geometry = "point",  type='FeatureCollection',
+                                      convert_crs = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
 }
 
 #' @export
-geojson_json.SpatialRingsDataFrame <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                               geometry = "point",  type='FeatureCollection', ...) {
-  class_json(geojson_rw(input, target = "char"), ...)
+geojson_json.SpatialRingsDataFrame <- function(input, lat = NULL, lon = NULL, 
+                                               group = NULL, geometry = "point",  
+                                               type='FeatureCollection',
+                                               convert_crs = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
 }
 
 #' @export
-geojson_json.SpatialCollections <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                            geometry = "point",  type='FeatureCollection', ...) {
-  lapply(geojson_rw(input, target = "char", ...), class_json)
+geojson_json.SpatialCollections <- function(input, lat = NULL, lon = NULL, 
+                                            group = NULL, geometry = "point",  
+                                            type='FeatureCollection',
+                                            convert_crs = FALSE, crs = NULL, ...) {
+  lapply(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs, ...), class_json)
 }
 
 # regular R classes --------------------------

--- a/R/geojson_json.R
+++ b/R/geojson_json.R
@@ -10,8 +10,8 @@
 #' @param type  (character)The type of collection. One of FeatureCollection (default) or GeometryCollection.
 #' @param group (character) A grouping variable to perform grouping for polygons - doesn't
 #' apply for points
-#' @param convert_crs Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.
-#' @param crs The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.
+#' @param convert_wgs84 Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.
+#' @param crs The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_wgs84} is \code{FALSE} or the object already has a CRS.
 #' @param ... Further args passed on to \code{\link[jsonlite]{toJSON}}
 #'
 #' @return An object of class \code{geo_json} (and \code{json})
@@ -210,7 +210,7 @@
 #' }
 geojson_json <- function(input, lat = NULL, lon = NULL, group = NULL,
                          geometry = "point", type='FeatureCollection',
-                         convert_crs = FALSE, crs = NULL, ...) {
+                         convert_wgs84 = FALSE, crs = NULL, ...) {
   UseMethod("geojson_json")
 }
 
@@ -218,77 +218,77 @@ geojson_json <- function(input, lat = NULL, lon = NULL, group = NULL,
 #' @export
 geojson_json.SpatialPolygons <- function(input, lat = NULL, lon = NULL, group = NULL,
                                          geometry = "point",  type='FeatureCollection',
-                                         convert_crs = FALSE, crs = NULL, ...) {
-  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
+                                         convert_wgs84 = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), ...)
 }
 
 #' @export
 geojson_json.SpatialPolygonsDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                   group = NULL, geometry = "point",  
                                                   type='FeatureCollection',
-                                                  convert_crs = FALSE, crs = NULL, ...) {
-  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
+                                                  convert_wgs84 = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), ...)
 }
 
 #' @export
 geojson_json.SpatialPoints <- function(input, lat = NULL, lon = NULL, group = NULL,
                                        geometry = "point",  type='FeatureCollection',
-                                       convert_crs = FALSE, crs = NULL, ...) {
+                                       convert_wgs84 = FALSE, crs = NULL, ...) {
   dat <- SpatialPointsDataFrame(input, data.frame(dat = 1:NROW(input@coords)))
-  class_json(geojson_rw(dat, target = "char", convert_crs = convert_crs, crs = crs), ...)
+  class_json(geojson_rw(dat, target = "char", convert_wgs84 = convert_wgs84, crs = crs), ...)
 }
 
 #' @export
 geojson_json.SpatialPointsDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                 group = NULL, geometry = "point",  
                                                 type='FeatureCollection',
-                                                convert_crs = FALSE, crs = NULL, ...) {
-  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
+                                                convert_wgs84 = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), ...)
 }
 
 #' @export
 geojson_json.SpatialLines <- function(input, lat = NULL, lon = NULL, group = NULL,
                                       geometry = "point",  type='FeatureCollection',
-                                      convert_crs = FALSE, crs = NULL, ...) {
-  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
+                                      convert_wgs84 = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), ...)
 }
 
 #' @export
 geojson_json.SpatialLinesDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                group = NULL, geometry = "point",  
                                                type='FeatureCollection',
-                                               convert_crs = FALSE, crs = NULL, ...) {
-  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
+                                               convert_wgs84 = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), ...)
 }
 
 #' @export
 geojson_json.SpatialGrid <- function(input, lat = NULL, lon = NULL, group = NULL,
                                      geometry = "point",  type='FeatureCollection',
-                                     convert_crs = FALSE, crs = NULL, ...) {
-  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
+                                     convert_wgs84 = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), ...)
 }
 
 #' @export
 geojson_json.SpatialGridDataFrame <- function(input, lat = NULL, lon = NULL, 
                                               group = NULL, geometry = "point",  
                                               type='FeatureCollection',
-                                              convert_crs = FALSE, crs = NULL, ...) {
-  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
+                                              convert_wgs84 = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), ...)
 }
 
 #' @export
 geojson_json.SpatialPixels <- function(input, lat = NULL, lon = NULL, group = NULL,
                                        geometry = "point",  type='FeatureCollection',
-                                       convert_crs = FALSE, crs = NULL, ...) {
-  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
+                                       convert_wgs84 = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), ...)
 }
 
 #' @export
 geojson_json.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                 group = NULL, geometry = "point",  
                                                 type='FeatureCollection',
-                                                convert_crs = FALSE, crs = NULL, ...) {
-  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
+                                                convert_wgs84 = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), ...)
 }
 
 # sf classes ---------------------------------
@@ -296,21 +296,21 @@ geojson_json.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL,
 #' @export
 geojson_json.sf <- function(input, lat = NULL, lon = NULL, group = NULL,
                             geometry = "point",  type='FeatureCollection',
-                            convert_crs = FALSE, crs = NULL, ...) {
-  as.json(geojson_list(input, convert_crs = convert_crs, crs = crs), ...)
+                            convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.json(geojson_list(input, convert_wgs84 = convert_wgs84, crs = crs), ...)
 }
 
 #' @export
 geojson_json.sfc <- function(input, lat = NULL, lon = NULL, group = NULL,
                              geometry = "point",  type='FeatureCollection',
-                             convert_crs = FALSE, crs = NULL, ...) {
-  as.json(geojson_list(input, convert_crs = convert_crs, crs = crs), ...)
+                             convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.json(geojson_list(input, convert_wgs84 = convert_wgs84, crs = crs), ...)
 }
 
 #' @export
 geojson_json.sfg <- function(input, lat = NULL, lon = NULL, group = NULL,
                              geometry = "point",  type='FeatureCollection',
-                             convert_crs = FALSE, crs = NULL, ...) {
+                             convert_wgs84 = FALSE, crs = NULL, ...) {
   as.json(geojson_list(input), ...)
 }
 
@@ -318,24 +318,24 @@ geojson_json.sfg <- function(input, lat = NULL, lon = NULL, group = NULL,
 #' @export
 geojson_json.SpatialRings <- function(input, lat = NULL, lon = NULL, group = NULL,
                                       geometry = "point",  type='FeatureCollection',
-                                      convert_crs = FALSE, crs = NULL, ...) {
-  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
+                                      convert_wgs84 = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), ...)
 }
 
 #' @export
 geojson_json.SpatialRingsDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                group = NULL, geometry = "point",  
                                                type='FeatureCollection',
-                                               convert_crs = FALSE, crs = NULL, ...) {
-  class_json(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs), ...)
+                                               convert_wgs84 = FALSE, crs = NULL, ...) {
+  class_json(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), ...)
 }
 
 #' @export
 geojson_json.SpatialCollections <- function(input, lat = NULL, lon = NULL, 
                                             group = NULL, geometry = "point",  
                                             type='FeatureCollection',
-                                            convert_crs = FALSE, crs = NULL, ...) {
-  lapply(geojson_rw(input, target = "char", convert_crs = convert_crs, crs = crs, ...), class_json)
+                                            convert_wgs84 = FALSE, crs = NULL, ...) {
+  lapply(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs, ...), class_json)
 }
 
 # regular R classes --------------------------

--- a/R/geojson_json.R
+++ b/R/geojson_json.R
@@ -11,7 +11,7 @@
 #' @param group (character) A grouping variable to perform grouping for polygons - doesn't
 #' apply for points
 #' @param convert_crs Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.
-#' @param crs The CRS of the input if it is not already defined. For \code{sf} objects this can be an epsg code as a four or five digit integer or a valid proj4 string. For \code{Spatial} obects it must be a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.
+#' @param crs The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.
 #' @param ... Further args passed on to \code{\link[jsonlite]{toJSON}}
 #'
 #' @return An object of class \code{geo_json} (and \code{json})

--- a/R/geojson_json.R
+++ b/R/geojson_json.R
@@ -235,7 +235,7 @@ geojson_json.SpatialPoints <- function(input, lat = NULL, lon = NULL, group = NU
                                        geometry = "point",  type='FeatureCollection',
                                        convert_crs = FALSE, crs = NULL, ...) {
   dat <- SpatialPointsDataFrame(input, data.frame(dat = 1:NROW(input@coords)))
-  class_json(geojson_rw(dat, target = "char", convert_crs = convert_crs, crs = crs))
+  class_json(geojson_rw(dat, target = "char", convert_crs = convert_crs, crs = crs), ...)
 }
 
 #' @export
@@ -297,21 +297,21 @@ geojson_json.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL,
 geojson_json.sf <- function(input, lat = NULL, lon = NULL, group = NULL,
                             geometry = "point",  type='FeatureCollection',
                             convert_crs = FALSE, crs = NULL, ...) {
-  as.json(geojson_list(input, convert_crs = convert_crs, crs = crs))
+  as.json(geojson_list(input, convert_crs = convert_crs, crs = crs), ...)
 }
 
 #' @export
 geojson_json.sfc <- function(input, lat = NULL, lon = NULL, group = NULL,
                              geometry = "point",  type='FeatureCollection',
                              convert_crs = FALSE, crs = NULL, ...) {
-  as.json(geojson_list(input, convert_crs = convert_crs, crs = crs))
+  as.json(geojson_list(input, convert_crs = convert_crs, crs = crs), ...)
 }
 
 #' @export
 geojson_json.sfg <- function(input, lat = NULL, lon = NULL, group = NULL,
                              geometry = "point",  type='FeatureCollection',
                              convert_crs = FALSE, crs = NULL, ...) {
-  as.json(geojson_list(input))
+  as.json(geojson_list(input), ...)
 }
 
 # spatial classes from rgeos --------------------------

--- a/R/geojson_list.R
+++ b/R/geojson_list.R
@@ -336,7 +336,7 @@ geojson_list.sf <- function(input, lat = NULL, lon = NULL, group = NULL,
                             geometry = "point", type = "FeatureCollection",
                             convert_crs = FALSE, crs = NULL, ...) {
   if (convert_crs) {
-  input <- convert_crs(input, crs)
+    input <- convert_crs(input, crs)
   }
   
   sf_col <- get_sf_column_name(input)

--- a/R/geojson_list.R
+++ b/R/geojson_list.R
@@ -298,7 +298,6 @@ geojson_list.sf <- function(input, lat = NULL, lon = NULL, group = NULL,
                             geometry = "point", type = "FeatureCollection", ...) {
   
   # input <- detect_convert_crs(input)
-  is_wgs84(input)
   
   sf_col <- get_sf_column_name(input)
   ## Get the sfc column
@@ -325,7 +324,6 @@ geojson_list.sf <- function(input, lat = NULL, lon = NULL, group = NULL,
 geojson_list.sfc <- function(input, lat = NULL, lon = NULL, group = NULL,
                              geometry = "point", type = "FeatureCollection", ...) {
   # input <- detect_convert_crs(input)
-  is_wgs84(input)
   ## A GeometryCollection except if length 1, then just return the geometry
   
   if (length(input) == 1) {

--- a/R/geojson_list.R
+++ b/R/geojson_list.R
@@ -11,6 +11,8 @@
 #' GeometryCollection.
 #' @param group (character) A grouping variable to perform grouping for polygons - doesn't apply
 #' for points
+#' @param convert_crs Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.
+#' @param crs The CRS of the input if it is not already defined. For \code{sf} objects this can be an epsg code as a four or five digit integer or a valid proj4 string. For \code{Spatial} obects it must be a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.
 #' @param ... Ignored
 #'
 #' @details This function creates a geojson structure as an R list; it does not write a file

--- a/R/geojson_list.R
+++ b/R/geojson_list.R
@@ -192,92 +192,128 @@
 #' 
 
 geojson_list <- function(input, lat = NULL, lon = NULL, group = NULL,
-                         geometry = "point", type = "FeatureCollection", ...) {
+                         geometry = "point", type = "FeatureCollection",
+                         convert_crs = FALSE, crs = NULL, ...) {
   UseMethod("geojson_list")
 }
 
 # spatial classes from sp --------------------------
 #' @export
 geojson_list.SpatialPolygons <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                         geometry = "point", type = "FeatureCollection", ...) {
-  as.geo_list(geojson_rw(input, target = "list"), "SpatialPolygons")
+                                         geometry = "point", type = "FeatureCollection",
+                                         convert_crs = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+              "SpatialPolygons")
 }
 
 #' @export
-geojson_list.SpatialPolygonsDataFrame <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                                  geometry = "point", type = "FeatureCollection", ...) {
-  as.geo_list(geojson_rw(input, target = "list"), "SpatialPolygonsDataFrame")
+geojson_list.SpatialPolygonsDataFrame <- function(input, lat = NULL, lon = NULL, 
+                                                  group = NULL, geometry = "point", 
+                                                  type = "FeatureCollection",
+                                                  convert_crs = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+              "SpatialPolygonsDataFrame")
 }
 
 #' @export
 geojson_list.SpatialPoints <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                       geometry = "point", type = "FeatureCollection", ...) {
+                                       geometry = "point", type = "FeatureCollection",
+                                       convert_crs = FALSE, crs = NULL, ...) {
   dat <- SpatialPointsDataFrame(input, data.frame(dat = 1:NROW(input@coords)))
-  as.geo_list(geojson_rw(dat, target = "list"), "SpatialPoints")
+  as.geo_list(geojson_rw(dat, target = "list", convert_crs = convert_crs, crs = crs), "SpatialPoints")
 }
 
 #' @export
-geojson_list.SpatialPointsDataFrame <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                                geometry = "point", type = "FeatureCollection", ...) {
-  as.geo_list(geojson_rw(input, target = "list"), "SpatialPointsDataFrame")
+geojson_list.SpatialPointsDataFrame <- function(input, lat = NULL, lon = NULL, 
+                                                group = NULL, geometry = "point", 
+                                                type = "FeatureCollection",
+                                                convert_crs = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+              "SpatialPointsDataFrame")
 }
 
 #' @export
 geojson_list.SpatialLines <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                      geometry = "point", type = "FeatureCollection", ...) {
-  as.geo_list(geojson_rw(input, target = "list"), "SpatialLines")
+                                      geometry = "point", type = "FeatureCollection",
+                                      convert_crs = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+              "SpatialLines")
 }
 
 #' @export
-geojson_list.SpatialLinesDataFrame <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                               geometry = "point", type = "FeatureCollection", ...) {
-  as.geo_list(geojson_rw(input, target = "list"), "SpatialLinesDataFrame")
+geojson_list.SpatialLinesDataFrame <- function(input, lat = NULL, lon = NULL, 
+                                               group = NULL, geometry = "point", 
+                                               type = "FeatureCollection",
+                                               convert_crs = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+              "SpatialLinesDataFrame")
 }
 
 #' @export
 geojson_list.SpatialGrid <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                     geometry = "point", type = "FeatureCollection", ...) {
-  as.geo_list(geojson_rw(input, target = "list"), "SpatialGrid")
+                                     geometry = "point", type = "FeatureCollection",
+                                     convert_crs = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+              "SpatialGrid")
 }
 
 #' @export
-geojson_list.SpatialGridDataFrame <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                              geometry = "point", type = "FeatureCollection", ...) {
-  as.geo_list(geojson_rw(input, target = "list"), "SpatialGridDataFrame")
+geojson_list.SpatialGridDataFrame <- function(input, lat = NULL, lon = NULL, 
+                                              group = NULL, geometry = "point", 
+                                              type = "FeatureCollection",
+                                              convert_crs = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+              "SpatialGridDataFrame")
 }
 
 #' @export
 geojson_list.SpatialPixels <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                       geometry = "point",  type='FeatureCollection', ...) {
-  as.geo_list(geojson_rw(input, target = "list"), "SpatialPixels")
+                                       geometry = "point",  type='FeatureCollection',
+                                       convert_crs = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+              "SpatialPixels")
 }
 
 #' @export
-geojson_list.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                                geometry = "point",  type='FeatureCollection', ...) {
-  as.geo_list(geojson_rw(input, target = "list"), "SpatialPixelsDataFrame")
+geojson_list.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL, 
+                                                group = NULL, geometry = "point", 
+                                                type = "FeatureCollection",
+                                                convert_crs = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+              "SpatialPixelsDataFrame")
 }
 
 # spatial classes from rgeos --------------------------
 #' @export
 geojson_list.SpatialRings <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                      geometry = "point",  type='FeatureCollection', ...) {
-  as.geo_list(geojson_rw(input, target = "list"), "SpatialRings")
+                                      geometry = "point",  type='FeatureCollection',
+                                      convert_crs = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+              "SpatialRings")
 }
 
 #' @export
-geojson_list.SpatialRingsDataFrame <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                               geometry = "point",  type='FeatureCollection', ...) {
-  as.geo_list(geojson_rw(input, target = "list"), "SpatialRingsDataFrame")
+geojson_list.SpatialRingsDataFrame <- function(input, lat = NULL, lon = NULL, 
+                                               group = NULL, geometry = "point", 
+                                               type = "FeatureCollection",
+                                               convert_crs = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+              "SpatialRingsDataFrame")
 }
 
 #' @export
-geojson_list.SpatialCollections <- function(input, lat = NULL, lon = NULL, group = NULL,
-                                            geometry = "point",  type='FeatureCollection', ...) {
-  pt <- donotnull(input@pointobj, geojson_rw, target = "list")
-  ln <- donotnull(input@lineobj, geojson_rw, target = "list")
-  rg <- donotnull(input@ringobj, geojson_rw, target = "list")
-  py <- donotnull(input@polyobj, geojson_rw, target = "list")
+geojson_list.SpatialCollections <- function(input, lat = NULL, lon = NULL, 
+                                            group = NULL, geometry = "point", 
+                                            type = "FeatureCollection",
+                                            convert_crs = FALSE, crs = NULL, ...) {
+  pt <- donotnull(input@pointobj, geojson_rw, target = "list", 
+                  convert_crs = convert_crs, crs = crs)
+  ln <- donotnull(input@lineobj, geojson_rw, target = "list", 
+                  convert_crs = convert_crs, crs = crs)
+  rg <- donotnull(input@ringobj, geojson_rw, target = "list", 
+                  convert_crs = convert_crs, crs = crs)
+  py <- donotnull(input@polyobj, geojson_rw, target = "list", 
+                  convert_crs = convert_crs, crs = crs)
   alldat <- tg_compact(list(SpatialPoints = pt, SpatialLines = ln, 
                             SpatialRings = rg, SpatialPolygons = py))
   as.geo_list(alldat, "SpatialCollections")
@@ -295,9 +331,11 @@ donotnull <- function(x, fun, ...) {
 
 #' @export
 geojson_list.sf <- function(input, lat = NULL, lon = NULL, group = NULL,
-                            geometry = "point", type = "FeatureCollection", ...) {
-  
-  # input <- detect_convert_crs(input)
+                            geometry = "point", type = "FeatureCollection",
+                            convert_crs = FALSE, crs = NULL, ...) {
+  if (convert_crs) {
+  input <- convert_crs(input, crs)
+  }
   
   sf_col <- get_sf_column_name(input)
   ## Get the sfc column
@@ -322,8 +360,11 @@ geojson_list.sf <- function(input, lat = NULL, lon = NULL, group = NULL,
 
 #' @export
 geojson_list.sfc <- function(input, lat = NULL, lon = NULL, group = NULL,
-                             geometry = "point", type = "FeatureCollection", ...) {
-  # input <- detect_convert_crs(input)
+                             geometry = "point", type = "FeatureCollection",
+                             convert_crs = FALSE, crs = NULL, ...) {
+  if (convert_crs) {
+    input <- convert_crs(input, crs)
+  }
   ## A GeometryCollection except if length 1, then just return the geometry
   
   if (length(input) == 1) {
@@ -337,10 +378,10 @@ geojson_list.sfc <- function(input, lat = NULL, lon = NULL, group = NULL,
 
 #' @export
 geojson_list.sfg <- function(input, lat = NULL, lon = NULL, group = NULL,
-                             geometry = "point", type = "FeatureCollection", ...) {
-  type <-  switch_geom_type(get_geometry_type(input))
+                             geometry = "point", type = "FeatureCollection",
+                             convert_crs = FALSE, crs = NULL, ...) {
   
-  # input <- detect_convert_crs(input)
+  type <-  switch_geom_type(get_geometry_type(input))
   
   if (type == "GeometryCollection") {
     geometries <- lapply(input, function(x) unclass(geojson_list(x)))

--- a/R/geojson_list.R
+++ b/R/geojson_list.R
@@ -11,8 +11,8 @@
 #' GeometryCollection.
 #' @param group (character) A grouping variable to perform grouping for polygons - doesn't apply
 #' for points
-#' @param convert_crs Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.
-#' @param crs The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.
+#' @param convert_wgs84 Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.
+#' @param crs The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_wgs84} is \code{FALSE} or the object already has a CRS.
 #' @param ... Ignored
 #'
 #' @details This function creates a geojson structure as an R list; it does not write a file
@@ -195,7 +195,7 @@
 
 geojson_list <- function(input, lat = NULL, lon = NULL, group = NULL,
                          geometry = "point", type = "FeatureCollection",
-                         convert_crs = FALSE, crs = NULL, ...) {
+                         convert_wgs84 = FALSE, crs = NULL, ...) {
   UseMethod("geojson_list")
 }
 
@@ -203,8 +203,8 @@ geojson_list <- function(input, lat = NULL, lon = NULL, group = NULL,
 #' @export
 geojson_list.SpatialPolygons <- function(input, lat = NULL, lon = NULL, group = NULL,
                                          geometry = "point", type = "FeatureCollection",
-                                         convert_crs = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+                                         convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialPolygons")
 }
 
@@ -212,33 +212,33 @@ geojson_list.SpatialPolygons <- function(input, lat = NULL, lon = NULL, group = 
 geojson_list.SpatialPolygonsDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                   group = NULL, geometry = "point", 
                                                   type = "FeatureCollection",
-                                                  convert_crs = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+                                                  convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialPolygonsDataFrame")
 }
 
 #' @export
 geojson_list.SpatialPoints <- function(input, lat = NULL, lon = NULL, group = NULL,
                                        geometry = "point", type = "FeatureCollection",
-                                       convert_crs = FALSE, crs = NULL, ...) {
+                                       convert_wgs84 = FALSE, crs = NULL, ...) {
   dat <- SpatialPointsDataFrame(input, data.frame(dat = 1:NROW(input@coords)))
-  as.geo_list(geojson_rw(dat, target = "list", convert_crs = convert_crs, crs = crs), "SpatialPoints")
+  as.geo_list(geojson_rw(dat, target = "list", convert_wgs84 = convert_wgs84, crs = crs), "SpatialPoints")
 }
 
 #' @export
 geojson_list.SpatialPointsDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                 group = NULL, geometry = "point", 
                                                 type = "FeatureCollection",
-                                                convert_crs = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+                                                convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialPointsDataFrame")
 }
 
 #' @export
 geojson_list.SpatialLines <- function(input, lat = NULL, lon = NULL, group = NULL,
                                       geometry = "point", type = "FeatureCollection",
-                                      convert_crs = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+                                      convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialLines")
 }
 
@@ -246,16 +246,16 @@ geojson_list.SpatialLines <- function(input, lat = NULL, lon = NULL, group = NUL
 geojson_list.SpatialLinesDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                group = NULL, geometry = "point", 
                                                type = "FeatureCollection",
-                                               convert_crs = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+                                               convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialLinesDataFrame")
 }
 
 #' @export
 geojson_list.SpatialGrid <- function(input, lat = NULL, lon = NULL, group = NULL,
                                      geometry = "point", type = "FeatureCollection",
-                                     convert_crs = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+                                     convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialGrid")
 }
 
@@ -263,16 +263,16 @@ geojson_list.SpatialGrid <- function(input, lat = NULL, lon = NULL, group = NULL
 geojson_list.SpatialGridDataFrame <- function(input, lat = NULL, lon = NULL, 
                                               group = NULL, geometry = "point", 
                                               type = "FeatureCollection",
-                                              convert_crs = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+                                              convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialGridDataFrame")
 }
 
 #' @export
 geojson_list.SpatialPixels <- function(input, lat = NULL, lon = NULL, group = NULL,
                                        geometry = "point",  type='FeatureCollection',
-                                       convert_crs = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+                                       convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialPixels")
 }
 
@@ -280,8 +280,8 @@ geojson_list.SpatialPixels <- function(input, lat = NULL, lon = NULL, group = NU
 geojson_list.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                 group = NULL, geometry = "point", 
                                                 type = "FeatureCollection",
-                                                convert_crs = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+                                                convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialPixelsDataFrame")
 }
 
@@ -289,8 +289,8 @@ geojson_list.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL,
 #' @export
 geojson_list.SpatialRings <- function(input, lat = NULL, lon = NULL, group = NULL,
                                       geometry = "point",  type='FeatureCollection',
-                                      convert_crs = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+                                      convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialRings")
 }
 
@@ -298,8 +298,8 @@ geojson_list.SpatialRings <- function(input, lat = NULL, lon = NULL, group = NUL
 geojson_list.SpatialRingsDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                group = NULL, geometry = "point", 
                                                type = "FeatureCollection",
-                                               convert_crs = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_crs = convert_crs, crs = crs),
+                                               convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialRingsDataFrame")
 }
 
@@ -307,15 +307,15 @@ geojson_list.SpatialRingsDataFrame <- function(input, lat = NULL, lon = NULL,
 geojson_list.SpatialCollections <- function(input, lat = NULL, lon = NULL, 
                                             group = NULL, geometry = "point", 
                                             type = "FeatureCollection",
-                                            convert_crs = FALSE, crs = NULL, ...) {
+                                            convert_wgs84 = FALSE, crs = NULL, ...) {
   pt <- donotnull(input@pointobj, geojson_rw, target = "list", 
-                  convert_crs = convert_crs, crs = crs)
+                  convert_wgs84 = convert_wgs84, crs = crs)
   ln <- donotnull(input@lineobj, geojson_rw, target = "list", 
-                  convert_crs = convert_crs, crs = crs)
+                  convert_wgs84 = convert_wgs84, crs = crs)
   rg <- donotnull(input@ringobj, geojson_rw, target = "list", 
-                  convert_crs = convert_crs, crs = crs)
+                  convert_wgs84 = convert_wgs84, crs = crs)
   py <- donotnull(input@polyobj, geojson_rw, target = "list", 
-                  convert_crs = convert_crs, crs = crs)
+                  convert_wgs84 = convert_wgs84, crs = crs)
   alldat <- tg_compact(list(SpatialPoints = pt, SpatialLines = ln, 
                             SpatialRings = rg, SpatialPolygons = py))
   as.geo_list(alldat, "SpatialCollections")
@@ -334,9 +334,9 @@ donotnull <- function(x, fun, ...) {
 #' @export
 geojson_list.sf <- function(input, lat = NULL, lon = NULL, group = NULL,
                             geometry = "point", type = "FeatureCollection",
-                            convert_crs = FALSE, crs = NULL, ...) {
-  if (convert_crs) {
-    input <- convert_crs(input, crs)
+                            convert_wgs84 = FALSE, crs = NULL, ...) {
+  if (convert_wgs84) {
+    input <- convert_wgs84(input, crs)
   }
   
   sf_col <- get_sf_column_name(input)
@@ -363,9 +363,9 @@ geojson_list.sf <- function(input, lat = NULL, lon = NULL, group = NULL,
 #' @export
 geojson_list.sfc <- function(input, lat = NULL, lon = NULL, group = NULL,
                              geometry = "point", type = "FeatureCollection",
-                             convert_crs = FALSE, crs = NULL, ...) {
-  if (convert_crs) {
-    input <- convert_crs(input, crs)
+                             convert_wgs84 = FALSE, crs = NULL, ...) {
+  if (convert_wgs84) {
+    input <- convert_wgs84(input, crs)
   }
   ## A GeometryCollection except if length 1, then just return the geometry
   
@@ -381,7 +381,7 @@ geojson_list.sfc <- function(input, lat = NULL, lon = NULL, group = NULL,
 #' @export
 geojson_list.sfg <- function(input, lat = NULL, lon = NULL, group = NULL,
                              geometry = "point", type = "FeatureCollection",
-                             convert_crs = FALSE, crs = NULL, ...) {
+                             convert_wgs84 = FALSE, crs = NULL, ...) {
   
   type <-  switch_geom_type(get_geometry_type(input))
   

--- a/R/geojson_list.R
+++ b/R/geojson_list.R
@@ -392,37 +392,6 @@ drop_m.list <- function(input, m_loc) lapply(input, drop_m, m_loc = m_loc)
 drop_m.numeric <- function(input, m_loc) input[-m_loc]
 drop_m.matrix <- function(input, m_loc) input[, -m_loc, drop = FALSE]
 
-# detect_convert_crs <- function(x) {
-#   if (!is_wgs84(x, warn = FALSE)) {
-#     if (!requireNamespace("sf", quietly = TRUE)) {
-#       stop("Your input is not in a CRS that geojson supports and you don't have the 'sf' package installed. Please install and try again")
-#     } else {
-#       message("Converting CRS from EPSG:", get_epsg(x), " to WGS84.")
-#       x <- sf::st_transform(x, 4326)
-#     }
-#   }
-#   x
-# }
-
-is_wgs84 <- function(x, warn = TRUE) {
-  epsg <- get_epsg(x)
-  is_it <- is.na(epsg) || epsg == 4326 # Give NA epsg the benefit of the doubt
-  if (!is_it && warn) {
-    warning("Input CRS is not WGS84 (epsg:4326), the standard for GeoJSON")
-  }
-  is_it
-}
-
-## Get epsg code
-get_epsg <- function(x) UseMethod("get_epsg")
-
-get_epsg.sf <- function(x) {
-  geom_col <- get_sf_column_name(x)
-  get_epsg(x[[geom_col]])
-}
-
-get_epsg.sfc <- function(x) attr(x, "crs")[["epsg"]]
-
 # regular R classes --------------------------
 #' @export
 geojson_list.numeric <- function(input, lat = NULL, lon = NULL, group = NULL,

--- a/R/geojson_list.R
+++ b/R/geojson_list.R
@@ -12,7 +12,7 @@
 #' @param group (character) A grouping variable to perform grouping for polygons - doesn't apply
 #' for points
 #' @param convert_crs Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.
-#' @param crs The CRS of the input if it is not already defined. For \code{sf} objects this can be an epsg code as a four or five digit integer or a valid proj4 string. For \code{Spatial} obects it must be a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.
+#' @param crs The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.
 #' @param ... Ignored
 #'
 #' @details This function creates a geojson structure as an R list; it does not write a file

--- a/R/geojson_write.r
+++ b/R/geojson_write.r
@@ -23,7 +23,7 @@
 #'   geojson file. Using fewer decimal places can decrease file sizes (at the
 #'   cost of precision).
 #' @param convert_crs Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.
-#' @param crs The CRS of the input if it is not already defined. For \code{sf} objects this can be an epsg code as a four or five digit integer or a valid proj4 string. For \code{Spatial} obects it must be a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.
+#' @param crs The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.
 #' @param ... Further args passed on to \code{\link[rgdal]{writeOGR}}
 #'   
 #' @seealso \code{\link{geojson_list}}, \code{\link{geojson_json}}

--- a/R/geojson_write.r
+++ b/R/geojson_write.r
@@ -145,7 +145,8 @@
 
 geojson_write <- function(input, lat = NULL, lon = NULL, geometry = "point",
                           group = NULL, file = "myfile.geojson", 
-                          overwrite = TRUE, precision = NULL, ...) {
+                          overwrite = TRUE, precision = NULL, 
+                          convert_crs = FALSE, crs = NULL, ...) {
   UseMethod("geojson_write")
 }
 
@@ -153,82 +154,105 @@ geojson_write <- function(input, lat = NULL, lon = NULL, geometry = "point",
 #' @export
 geojson_write.SpatialPolygons <- function(input, lat = NULL, lon = NULL, geometry = "point",
                                           group = NULL, file = "myfile.geojson", 
-                                          overwrite = TRUE, precision = NULL, ...) {
-  write_geojson(as(input, "SpatialPolygonsDataFrame"), file, precision = precision, ...)
+                                          overwrite = TRUE, precision = NULL, 
+                                          convert_crs = FALSE, crs = NULL, ...) {
+  write_geojson(as(input, "SpatialPolygonsDataFrame"), file, precision = precision, 
+                convert_crs = convert_crs, crs = crs, ...)
   return(as.geojson(file, "SpatialPolygons"))
 }
 
 #' @export
-geojson_write.SpatialPolygonsDataFrame <- function(input, lat = NULL, lon = NULL, geometry = "point",
+geojson_write.SpatialPolygonsDataFrame <- function(input, lat = NULL, lon = NULL, 
+                                                   geometry = "point",
                                                    group = NULL, file = "myfile.geojson", 
-                                                   overwrite = TRUE, precision = NULL, ...) {
-  write_geojson(input, file, precision = precision, ...)
+                                                   overwrite = TRUE, precision = NULL, 
+                                                   convert_crs = FALSE, crs = NULL, ...) {
+  write_geojson(input, file, precision = precision, convert_crs = convert_crs, 
+                crs = crs, ...)
   return(as.geojson(file, "SpatialPolygonsDataFrame"))
 }
 
 #' @export
 geojson_write.SpatialPoints <- function(input, lat = NULL, lon = NULL, geometry = "point",
                                         group = NULL, file = "myfile.geojson", 
-                                        overwrite = TRUE, precision = NULL, ...) {
-  write_geojson(as(input, "SpatialPointsDataFrame"), file, precision = precision, ...)
+                                        overwrite = TRUE, precision = NULL, 
+                                        convert_crs = FALSE, crs = NULL, ...) {
+  write_geojson(as(input, "SpatialPointsDataFrame"), file, precision = precision, 
+                convert_crs = convert_crs, crs = crs, ...)
   return(as.geojson(file, "SpatialPoints"))
 }
 
 #' @export
 geojson_write.SpatialPointsDataFrame <- function(input, lat = NULL, lon = NULL, geometry = "point",
                                                  group = NULL, file = "myfile.geojson", 
-                                                 overwrite = TRUE, precision = NULL, ...) {
-  write_geojson(input, file, precision = precision, ...)
+                                                 overwrite = TRUE, precision = NULL, 
+                                                 convert_crs = FALSE, crs = NULL, ...) {
+  write_geojson(input, file, precision = precision, convert_crs = convert_crs, 
+                crs = crs, ...)
   return(as.geojson(file, "SpatialPointsDataFrame"))
 }
 
 #' @export
 geojson_write.SpatialLines <- function(input, lat = NULL, lon = NULL, geometry = "point",
                                        group = NULL, file = "myfile.geojson", 
-                                       overwrite = TRUE, precision = NULL, ...) {
-  write_geojson(as(input, "SpatialLinesDataFrame"), file, precision = precision, ...)
+                                       overwrite = TRUE, precision = NULL, 
+                                       convert_crs = FALSE, crs = NULL, ...) {
+  write_geojson(as(input, "SpatialLinesDataFrame"), file, precision = precision, 
+                convert_crs = convert_crs, crs = crs, ...)
   return(as.geojson(file, "SpatialLines"))
 }
 
 #' @export
-geojson_write.SpatialLinesDataFrame <- function(input, lat = NULL, lon = NULL, geometry = "point",
+geojson_write.SpatialLinesDataFrame <- function(input, lat = NULL, lon = NULL, 
+                                                geometry = "point",
                                                 group = NULL, file = "myfile.geojson", 
-                                                overwrite = TRUE, precision = NULL, ...) {
-  write_geojson(input, file, precision = precision, ...)
+                                                overwrite = TRUE, precision = NULL, 
+                                                convert_crs = FALSE, crs = NULL, ...) {
+  write_geojson(input, file, precision = precision, convert_crs = convert_crs, 
+                crs = crs, ...)
   return(as.geojson(file, "SpatialLinesDataFrame"))
 }
 
 #' @export
 geojson_write.SpatialGrid <- function(input, lat = NULL, lon = NULL, geometry = "point",
                                       group = NULL, file = "myfile.geojson", 
-                                      overwrite = TRUE, precision = NULL, ...) {
+                                      overwrite = TRUE, precision = NULL, 
+                                      convert_crs = FALSE, crs = NULL, ...) {
   size <- prod(input@grid@cells.dim)
   input <- SpatialGridDataFrame(input, data.frame(val = rep(1, size)))
-  write_geojson(input, file, precision = precision, ...)
+  write_geojson(input, file, precision = precision, convert_crs = convert_crs, 
+                crs = crs, ...)
   return(as.geojson(file, "SpatialGrid"))
 }
 
 #' @export
-geojson_write.SpatialGridDataFrame <- function(input, lat = NULL, lon = NULL, geometry = "point",
+geojson_write.SpatialGridDataFrame <- function(input, lat = NULL, lon = NULL, 
+                                               geometry = "point",
                                                group = NULL, file = "myfile.geojson", 
-                                               overwrite = TRUE, precision = NULL, ...) {
-  write_geojson(as(input, "SpatialPointsDataFrame"), file, precision = precision, ...)
+                                               overwrite = TRUE, precision = NULL, 
+                                               convert_crs = FALSE, crs = NULL, ...) {
+  write_geojson(as(input, "SpatialPointsDataFrame"), file, precision = precision, 
+                convert_crs = convert_crs, crs = crs, ...)
   return(as.geojson(file, "SpatialGridDataFrame"))
 }
 
 #' @export
 geojson_write.SpatialPixels <- function(input, lat = NULL, lon = NULL, geometry = "point",
                                         group = NULL, file = "myfile.geojson", 
-                                        overwrite = TRUE, precision = NULL, ...) {
-  write_geojson(as(input, "SpatialPointsDataFrame"), file, precision = precision, ...)
+                                        overwrite = TRUE, precision = NULL, 
+                                        convert_crs = FALSE, crs = NULL, ...) {
+  write_geojson(as(input, "SpatialPointsDataFrame"), file, precision = precision, 
+                convert_crs = convert_crs, crs = crs, ...)
   return(as.geojson(file, "SpatialPixels"))
 }
 
 #' @export
 geojson_write.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL, geometry = "point",
                                                  group = NULL, file = "myfile.geojson", 
-                                                 overwrite = TRUE, precision = NULL, ...) {
-  write_geojson(as(input, "SpatialPointsDataFrame"), file, precision = precision, ...)
+                                                 overwrite = TRUE, precision = NULL, 
+                                                 convert_crs = FALSE, crs = NULL, ...) {
+  write_geojson(as(input, "SpatialPointsDataFrame"), file, precision = precision, 
+                convert_crs = convert_crs, crs = crs, ...)
   return(as.geojson(file, "SpatialPixelsDataFrame"))
 }
 
@@ -236,34 +260,46 @@ geojson_write.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL, 
 #' @export
 geojson_write.SpatialRings <- function(input, lat = NULL, lon = NULL, geometry = "point",
                                        group = NULL, file = "myfile.geojson", 
-                                       overwrite = TRUE, precision = NULL, ...) {
-  write_geojson(as(input, "SpatialPolygonsDataFrame"), file, precision = precision, ...)
+                                       overwrite = TRUE, precision = NULL, 
+                                       convert_crs = FALSE, crs = NULL, ...) {
+  write_geojson(as(input, "SpatialPolygonsDataFrame"), file, precision = precision, 
+                convert_crs = convert_crs, crs = crs, ...)
   return(as.geojson(file, "SpatialRings"))
 }
 
 #' @export
 geojson_write.SpatialRingsDataFrame <- function(input, lat = NULL, lon = NULL, geometry = "point",
                                                 group = NULL, file = "myfile.geojson", 
-                                                overwrite = TRUE, precision = NULL, ...) {
-  write_geojson(as(input, "SpatialPolygonsDataFrame"), file, precision = precision, ...)
+                                                overwrite = TRUE, precision = NULL, 
+                                                convert_crs = FALSE, crs = NULL, ...) {
+  write_geojson(as(input, "SpatialPolygonsDataFrame"), file, precision = precision, 
+                convert_crs = convert_crs, crs = crs, ...)
   return(as.geojson(file, "SpatialRingsDataFrame"))
 }
 
 #' @export
-geojson_write.SpatialCollections <- function(input, lat = NULL, lon = NULL, geometry = "point",
+geojson_write.SpatialCollections <- function(input, lat = NULL, lon = NULL, 
+                                             geometry = "point",
                                              group = NULL, file = "myfile.geojson", 
-                                             overwrite = TRUE, precision = NULL, ...) {
-  ptfile <- iter_spatialcoll(input@pointobj, file, precision = precision, ...)
-  lfile <- iter_spatialcoll(input@lineobj, file, precision = precision, ...)
-  rfile <- iter_spatialcoll(input@ringobj, file, precision = precision, ...)
-  pyfile <- iter_spatialcoll(input@polyobj, file, precision = precision, ...)
+                                             overwrite = TRUE, precision = NULL, 
+                                             convert_crs = FALSE, crs = NULL, ...) {
+  ptfile <- iter_spatialcoll(input@pointobj, file, precision = precision, 
+                             convert_crs = convert_crs, crs = crs, ...)
+  lfile <- iter_spatialcoll(input@lineobj, file, precision = precision, 
+                            convert_crs = convert_crs, crs = crs, ...)
+  rfile <- iter_spatialcoll(input@ringobj, file, precision = precision, 
+                            convert_crs = convert_crs, crs = crs, ...)
+  pyfile <- iter_spatialcoll(input@polyobj, file, precision = precision, 
+                             convert_crs = convert_crs, crs = crs, ...)
   return(structure(list(ptfile, lfile, rfile, pyfile), class = "spatialcoll"))
 }
 
-iter_spatialcoll <- function(z, file, precision = NULL, ...) {
+iter_spatialcoll <- function(z, file, precision = NULL, convert_crs = FALSE, 
+                             crs = NULL...) {
   wfile <- sprintf("%s/%s_%s", dirname(file), class(z)[1], basename(file))
   if (!is.null(z)) {
-    geojson_write(z, file = wfile, precision = precision, ...)
+    geojson_write(z, file = wfile, precision = precision, 
+                  convert_crs = convert_crs, crs = crs, ...)
   }
 }
 
@@ -271,22 +307,24 @@ iter_spatialcoll <- function(z, file, precision = NULL, ...) {
 #' @export
 geojson_write.sf <- function(input, lat = NULL, lon = NULL, geometry = "point",
                              group = NULL, file = "myfile.geojson", 
-                             overwrite = TRUE, ...) {
-  geojson_write(geojson_list(input), file = file, overwrite = overwrite)
+                             overwrite = TRUE, convert_crs = FALSE, crs = NULL, ...) {
+  geojson_write(geojson_list(input, convert_crs = convert_crs, crs = crs), file = file, overwrite = overwrite, ...)
 }
 
 #' @export
 geojson_write.sfc <- function(input, lat = NULL, lon = NULL, geometry = "point",
                               group = NULL, file = "myfile.geojson", 
-                              overwrite = TRUE, ...) {
-  geojson_write(geojson_list(input), file = file, overwrite = overwrite)
+                              overwrite = TRUE, convert_crs = FALSE, crs = NULL, ...) {
+  geojson_write(geojson_list(input, convert_crs = convert_crs, crs = crs), 
+                file = file, overwrite = overwrite, ...)
 }
 
 #' @export
 geojson_write.sfg <- function(input, lat = NULL, lon = NULL, geometry = "point",
                               group = NULL, file = "myfile.geojson", 
-                              overwrite = TRUE, ...) {
-  geojson_write(geojson_list(input), file = file, overwrite = overwrite)
+                              overwrite = TRUE, convert_crs = FALSE, crs = NULL, ...) {
+  geojson_write(geojson_list(input, convert_crs = convert_crs, crs = crs), 
+                file = file, overwrite = overwrite, ...)
 }
 
 ## normal R classes -----------------

--- a/R/geojson_write.r
+++ b/R/geojson_write.r
@@ -22,6 +22,8 @@
 #' @param precision desired number of decimal places for the coordinates in the
 #'   geojson file. Using fewer decimal places can decrease file sizes (at the
 #'   cost of precision).
+#' @param convert_crs Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.
+#' @param crs The CRS of the input if it is not already defined. For \code{sf} objects this can be an epsg code as a four or five digit integer or a valid proj4 string. For \code{Spatial} obects it must be a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.
 #' @param ... Further args passed on to \code{\link[rgdal]{writeOGR}}
 #'   
 #' @seealso \code{\link{geojson_list}}, \code{\link{geojson_json}}

--- a/R/geojson_write.r
+++ b/R/geojson_write.r
@@ -22,8 +22,8 @@
 #' @param precision desired number of decimal places for the coordinates in the
 #'   geojson file. Using fewer decimal places can decrease file sizes (at the
 #'   cost of precision).
-#' @param convert_crs Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.
-#' @param crs The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.
+#' @param convert_wgs84 Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.
+#' @param crs The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_wgs84} is \code{FALSE} or the object already has a CRS.
 #' @param ... Further args passed on to \code{\link[rgdal]{writeOGR}}
 #'   
 #' @seealso \code{\link{geojson_list}}, \code{\link{geojson_json}}
@@ -148,7 +148,7 @@
 geojson_write <- function(input, lat = NULL, lon = NULL, geometry = "point",
                           group = NULL, file = "myfile.geojson", 
                           overwrite = TRUE, precision = NULL, 
-                          convert_crs = FALSE, crs = NULL, ...) {
+                          convert_wgs84 = FALSE, crs = NULL, ...) {
   UseMethod("geojson_write")
 }
 
@@ -157,9 +157,9 @@ geojson_write <- function(input, lat = NULL, lon = NULL, geometry = "point",
 geojson_write.SpatialPolygons <- function(input, lat = NULL, lon = NULL, geometry = "point",
                                           group = NULL, file = "myfile.geojson", 
                                           overwrite = TRUE, precision = NULL, 
-                                          convert_crs = FALSE, crs = NULL, ...) {
+                                          convert_wgs84 = FALSE, crs = NULL, ...) {
   write_geojson(as(input, "SpatialPolygonsDataFrame"), file, precision = precision, 
-                convert_crs = convert_crs, crs = crs, ...)
+                convert_wgs84 = convert_wgs84, crs = crs, ...)
   return(as.geojson(file, "SpatialPolygons"))
 }
 
@@ -168,8 +168,8 @@ geojson_write.SpatialPolygonsDataFrame <- function(input, lat = NULL, lon = NULL
                                                    geometry = "point",
                                                    group = NULL, file = "myfile.geojson", 
                                                    overwrite = TRUE, precision = NULL, 
-                                                   convert_crs = FALSE, crs = NULL, ...) {
-  write_geojson(input, file, precision = precision, convert_crs = convert_crs, 
+                                                   convert_wgs84 = FALSE, crs = NULL, ...) {
+  write_geojson(input, file, precision = precision, convert_wgs84 = convert_wgs84, 
                 crs = crs, ...)
   return(as.geojson(file, "SpatialPolygonsDataFrame"))
 }
@@ -178,9 +178,9 @@ geojson_write.SpatialPolygonsDataFrame <- function(input, lat = NULL, lon = NULL
 geojson_write.SpatialPoints <- function(input, lat = NULL, lon = NULL, geometry = "point",
                                         group = NULL, file = "myfile.geojson", 
                                         overwrite = TRUE, precision = NULL, 
-                                        convert_crs = FALSE, crs = NULL, ...) {
+                                        convert_wgs84 = FALSE, crs = NULL, ...) {
   write_geojson(as(input, "SpatialPointsDataFrame"), file, precision = precision, 
-                convert_crs = convert_crs, crs = crs, ...)
+                convert_wgs84 = convert_wgs84, crs = crs, ...)
   return(as.geojson(file, "SpatialPoints"))
 }
 
@@ -188,8 +188,8 @@ geojson_write.SpatialPoints <- function(input, lat = NULL, lon = NULL, geometry 
 geojson_write.SpatialPointsDataFrame <- function(input, lat = NULL, lon = NULL, geometry = "point",
                                                  group = NULL, file = "myfile.geojson", 
                                                  overwrite = TRUE, precision = NULL, 
-                                                 convert_crs = FALSE, crs = NULL, ...) {
-  write_geojson(input, file, precision = precision, convert_crs = convert_crs, 
+                                                 convert_wgs84 = FALSE, crs = NULL, ...) {
+  write_geojson(input, file, precision = precision, convert_wgs84 = convert_wgs84, 
                 crs = crs, ...)
   return(as.geojson(file, "SpatialPointsDataFrame"))
 }
@@ -198,9 +198,9 @@ geojson_write.SpatialPointsDataFrame <- function(input, lat = NULL, lon = NULL, 
 geojson_write.SpatialLines <- function(input, lat = NULL, lon = NULL, geometry = "point",
                                        group = NULL, file = "myfile.geojson", 
                                        overwrite = TRUE, precision = NULL, 
-                                       convert_crs = FALSE, crs = NULL, ...) {
+                                       convert_wgs84 = FALSE, crs = NULL, ...) {
   write_geojson(as(input, "SpatialLinesDataFrame"), file, precision = precision, 
-                convert_crs = convert_crs, crs = crs, ...)
+                convert_wgs84 = convert_wgs84, crs = crs, ...)
   return(as.geojson(file, "SpatialLines"))
 }
 
@@ -209,8 +209,8 @@ geojson_write.SpatialLinesDataFrame <- function(input, lat = NULL, lon = NULL,
                                                 geometry = "point",
                                                 group = NULL, file = "myfile.geojson", 
                                                 overwrite = TRUE, precision = NULL, 
-                                                convert_crs = FALSE, crs = NULL, ...) {
-  write_geojson(input, file, precision = precision, convert_crs = convert_crs, 
+                                                convert_wgs84 = FALSE, crs = NULL, ...) {
+  write_geojson(input, file, precision = precision, convert_wgs84 = convert_wgs84, 
                 crs = crs, ...)
   return(as.geojson(file, "SpatialLinesDataFrame"))
 }
@@ -219,10 +219,10 @@ geojson_write.SpatialLinesDataFrame <- function(input, lat = NULL, lon = NULL,
 geojson_write.SpatialGrid <- function(input, lat = NULL, lon = NULL, geometry = "point",
                                       group = NULL, file = "myfile.geojson", 
                                       overwrite = TRUE, precision = NULL, 
-                                      convert_crs = FALSE, crs = NULL, ...) {
+                                      convert_wgs84 = FALSE, crs = NULL, ...) {
   size <- prod(input@grid@cells.dim)
   input <- SpatialGridDataFrame(input, data.frame(val = rep(1, size)))
-  write_geojson(input, file, precision = precision, convert_crs = convert_crs, 
+  write_geojson(input, file, precision = precision, convert_wgs84 = convert_wgs84, 
                 crs = crs, ...)
   return(as.geojson(file, "SpatialGrid"))
 }
@@ -232,9 +232,9 @@ geojson_write.SpatialGridDataFrame <- function(input, lat = NULL, lon = NULL,
                                                geometry = "point",
                                                group = NULL, file = "myfile.geojson", 
                                                overwrite = TRUE, precision = NULL, 
-                                               convert_crs = FALSE, crs = NULL, ...) {
+                                               convert_wgs84 = FALSE, crs = NULL, ...) {
   write_geojson(as(input, "SpatialPointsDataFrame"), file, precision = precision, 
-                convert_crs = convert_crs, crs = crs, ...)
+                convert_wgs84 = convert_wgs84, crs = crs, ...)
   return(as.geojson(file, "SpatialGridDataFrame"))
 }
 
@@ -242,9 +242,9 @@ geojson_write.SpatialGridDataFrame <- function(input, lat = NULL, lon = NULL,
 geojson_write.SpatialPixels <- function(input, lat = NULL, lon = NULL, geometry = "point",
                                         group = NULL, file = "myfile.geojson", 
                                         overwrite = TRUE, precision = NULL, 
-                                        convert_crs = FALSE, crs = NULL, ...) {
+                                        convert_wgs84 = FALSE, crs = NULL, ...) {
   write_geojson(as(input, "SpatialPointsDataFrame"), file, precision = precision, 
-                convert_crs = convert_crs, crs = crs, ...)
+                convert_wgs84 = convert_wgs84, crs = crs, ...)
   return(as.geojson(file, "SpatialPixels"))
 }
 
@@ -252,9 +252,9 @@ geojson_write.SpatialPixels <- function(input, lat = NULL, lon = NULL, geometry 
 geojson_write.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL, geometry = "point",
                                                  group = NULL, file = "myfile.geojson", 
                                                  overwrite = TRUE, precision = NULL, 
-                                                 convert_crs = FALSE, crs = NULL, ...) {
+                                                 convert_wgs84 = FALSE, crs = NULL, ...) {
   write_geojson(as(input, "SpatialPointsDataFrame"), file, precision = precision, 
-                convert_crs = convert_crs, crs = crs, ...)
+                convert_wgs84 = convert_wgs84, crs = crs, ...)
   return(as.geojson(file, "SpatialPixelsDataFrame"))
 }
 
@@ -263,9 +263,9 @@ geojson_write.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL, 
 geojson_write.SpatialRings <- function(input, lat = NULL, lon = NULL, geometry = "point",
                                        group = NULL, file = "myfile.geojson", 
                                        overwrite = TRUE, precision = NULL, 
-                                       convert_crs = FALSE, crs = NULL, ...) {
+                                       convert_wgs84 = FALSE, crs = NULL, ...) {
   write_geojson(as(input, "SpatialPolygonsDataFrame"), file, precision = precision, 
-                convert_crs = convert_crs, crs = crs, ...)
+                convert_wgs84 = convert_wgs84, crs = crs, ...)
   return(as.geojson(file, "SpatialRings"))
 }
 
@@ -273,9 +273,9 @@ geojson_write.SpatialRings <- function(input, lat = NULL, lon = NULL, geometry =
 geojson_write.SpatialRingsDataFrame <- function(input, lat = NULL, lon = NULL, geometry = "point",
                                                 group = NULL, file = "myfile.geojson", 
                                                 overwrite = TRUE, precision = NULL, 
-                                                convert_crs = FALSE, crs = NULL, ...) {
+                                                convert_wgs84 = FALSE, crs = NULL, ...) {
   write_geojson(as(input, "SpatialPolygonsDataFrame"), file, precision = precision, 
-                convert_crs = convert_crs, crs = crs, ...)
+                convert_wgs84 = convert_wgs84, crs = crs, ...)
   return(as.geojson(file, "SpatialRingsDataFrame"))
 }
 
@@ -284,24 +284,24 @@ geojson_write.SpatialCollections <- function(input, lat = NULL, lon = NULL,
                                              geometry = "point",
                                              group = NULL, file = "myfile.geojson", 
                                              overwrite = TRUE, precision = NULL, 
-                                             convert_crs = FALSE, crs = NULL, ...) {
+                                             convert_wgs84 = FALSE, crs = NULL, ...) {
   ptfile <- iter_spatialcoll(input@pointobj, file, precision = precision, 
-                             convert_crs = convert_crs, crs = crs, ...)
+                             convert_wgs84 = convert_wgs84, crs = crs, ...)
   lfile <- iter_spatialcoll(input@lineobj, file, precision = precision, 
-                            convert_crs = convert_crs, crs = crs, ...)
+                            convert_wgs84 = convert_wgs84, crs = crs, ...)
   rfile <- iter_spatialcoll(input@ringobj, file, precision = precision, 
-                            convert_crs = convert_crs, crs = crs, ...)
+                            convert_wgs84 = convert_wgs84, crs = crs, ...)
   pyfile <- iter_spatialcoll(input@polyobj, file, precision = precision, 
-                             convert_crs = convert_crs, crs = crs, ...)
+                             convert_wgs84 = convert_wgs84, crs = crs, ...)
   return(structure(list(ptfile, lfile, rfile, pyfile), class = "spatialcoll"))
 }
 
-iter_spatialcoll <- function(z, file, precision = NULL, convert_crs = FALSE, 
+iter_spatialcoll <- function(z, file, precision = NULL, convert_wgs84 = FALSE, 
                              crs = NULL, ...) {
   wfile <- sprintf("%s/%s_%s", dirname(file), class(z)[1], basename(file))
   if (!is.null(z)) {
     geojson_write(z, file = wfile, precision = precision, 
-                  convert_crs = convert_crs, crs = crs, ...)
+                  convert_wgs84 = convert_wgs84, crs = crs, ...)
   }
 }
 
@@ -310,16 +310,16 @@ iter_spatialcoll <- function(z, file, precision = NULL, convert_crs = FALSE,
 geojson_write.sf <- function(input, lat = NULL, lon = NULL, geometry = "point",
                              group = NULL, file = "myfile.geojson", 
                              overwrite = TRUE, precision = NULL,
-                             convert_crs = FALSE, crs = NULL, ...) {
-  geojson_write(geojson_list(input, convert_crs = convert_crs, crs = crs), file = file, overwrite = overwrite, ...)
+                             convert_wgs84 = FALSE, crs = NULL, ...) {
+  geojson_write(geojson_list(input, convert_wgs84 = convert_wgs84, crs = crs), file = file, overwrite = overwrite, ...)
 }
 
 #' @export
 geojson_write.sfc <- function(input, lat = NULL, lon = NULL, geometry = "point",
                               group = NULL, file = "myfile.geojson", 
                               overwrite = TRUE, precision = NULL,
-                              convert_crs = FALSE, crs = NULL, ...) {
-  geojson_write(geojson_list(input, convert_crs = convert_crs, crs = crs), 
+                              convert_wgs84 = FALSE, crs = NULL, ...) {
+  geojson_write(geojson_list(input, convert_wgs84 = convert_wgs84, crs = crs), 
                 file = file, overwrite = overwrite, ...)
 }
 
@@ -327,8 +327,8 @@ geojson_write.sfc <- function(input, lat = NULL, lon = NULL, geometry = "point",
 geojson_write.sfg <- function(input, lat = NULL, lon = NULL, geometry = "point",
                               group = NULL, file = "myfile.geojson", 
                               overwrite = TRUE, precision = NULL,
-                              convert_crs = FALSE, crs = NULL, ...) {
-  geojson_write(geojson_list(input, convert_crs = convert_crs, crs = crs), 
+                              convert_wgs84 = FALSE, crs = NULL, ...) {
+  geojson_write(geojson_list(input, convert_wgs84 = convert_wgs84, crs = crs), 
                 file = file, overwrite = overwrite, ...)
 }
 

--- a/R/geojson_write.r
+++ b/R/geojson_write.r
@@ -297,7 +297,7 @@ geojson_write.SpatialCollections <- function(input, lat = NULL, lon = NULL,
 }
 
 iter_spatialcoll <- function(z, file, precision = NULL, convert_crs = FALSE, 
-                             crs = NULL...) {
+                             crs = NULL, ...) {
   wfile <- sprintf("%s/%s_%s", dirname(file), class(z)[1], basename(file))
   if (!is.null(z)) {
     geojson_write(z, file = wfile, precision = precision, 
@@ -309,14 +309,16 @@ iter_spatialcoll <- function(z, file, precision = NULL, convert_crs = FALSE,
 #' @export
 geojson_write.sf <- function(input, lat = NULL, lon = NULL, geometry = "point",
                              group = NULL, file = "myfile.geojson", 
-                             overwrite = TRUE, convert_crs = FALSE, crs = NULL, ...) {
+                             overwrite = TRUE, precision = NULL,
+                             convert_crs = FALSE, crs = NULL, ...) {
   geojson_write(geojson_list(input, convert_crs = convert_crs, crs = crs), file = file, overwrite = overwrite, ...)
 }
 
 #' @export
 geojson_write.sfc <- function(input, lat = NULL, lon = NULL, geometry = "point",
                               group = NULL, file = "myfile.geojson", 
-                              overwrite = TRUE, convert_crs = FALSE, crs = NULL, ...) {
+                              overwrite = TRUE, precision = NULL,
+                              convert_crs = FALSE, crs = NULL, ...) {
   geojson_write(geojson_list(input, convert_crs = convert_crs, crs = crs), 
                 file = file, overwrite = overwrite, ...)
 }
@@ -324,7 +326,8 @@ geojson_write.sfc <- function(input, lat = NULL, lon = NULL, geometry = "point",
 #' @export
 geojson_write.sfg <- function(input, lat = NULL, lon = NULL, geometry = "point",
                               group = NULL, file = "myfile.geojson", 
-                              overwrite = TRUE, convert_crs = FALSE, crs = NULL, ...) {
+                              overwrite = TRUE, precision = NULL,
+                              convert_crs = FALSE, crs = NULL, ...) {
   geojson_write(geojson_list(input, convert_crs = convert_crs, crs = crs), 
                 file = file, overwrite = overwrite, ...)
 }

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -266,7 +266,7 @@ spdftogeolist <- function(x){
 }
 
 write_geojson <- function(input, file = "myfile.geojson", precision = NULL, 
-                          overwrite = TRUE, convert_crs = FALSE, crs = NULL, ...){
+                          overwrite = TRUE, convert_wgs84 = FALSE, crs = NULL, ...){
   if (!grepl("\\.geojson$", file)) {
     file <- paste0(file, ".geojson")
   }
@@ -274,14 +274,14 @@ write_geojson <- function(input, file = "myfile.geojson", precision = NULL,
   destpath <- dirname(file)
   if (!file.exists(destpath)) dir.create(destpath)
   write_ogr(input, tempfile(), file, precision, overwrite, 
-            convert_crs = convert_crs, crs = crs, ...)
+            convert_wgs84 = convert_wgs84, crs = crs, ...)
 }
 
 write_ogr <- function(input, dir, file, precision = NULL, overwrite, 
-                      convert_crs = FALSE, crs = NULL, ...){
+                      convert_wgs84 = FALSE, crs = NULL, ...){
   
-  if (convert_crs) {
-    input <- convert_crs(input, crs = crs)
+  if (convert_wgs84) {
+    input <- convert_wgs84(input, crs = crs)
   }
   
   input@data <- convert_ordered(input@data)
@@ -309,7 +309,7 @@ convert_ordered <- function(df) {
 }
 
 geojson_rw <- function(input, target = c("char", "list"), 
-                       convert_crs = FALSE, crs = NULL, ...){
+                       convert_wgs84 = FALSE, crs = NULL, ...){
 
   read_fun <- switch(target, 
                      char = geojson_file_to_char, 
@@ -318,13 +318,13 @@ geojson_rw <- function(input, target = c("char", "list"),
   if (inherits(input, "SpatialCollections")) {
     tmp <- tempfile(fileext = ".geojson")
     tmp2 <- suppressMessages(geojson_write(input, file = tmp, 
-                                           convert_crs = convert_crs, crs = crs))
+                                           convert_wgs84 = convert_wgs84, crs = crs))
     paths <- vapply(tg_compact(tmp2), "[[", "", "path")
     lapply(paths, read_fun, ...)
   } else {
     tmp <- tempfile(fileext = ".geojson")
     suppressMessages(geojson_write(input, file = tmp, 
-                                   convert_crs = convert_crs, crs = crs))
+                                   convert_wgs84 = convert_wgs84, crs = crs))
     read_fun(tmp, ...)
   }
 }

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -265,17 +265,25 @@ spdftogeolist <- function(x){
   }
 }
 
-write_geojson <- function(input, file = "myfile.geojson", precision = NULL, overwrite = TRUE, ...){
+write_geojson <- function(input, file = "myfile.geojson", precision = NULL, 
+                          overwrite = TRUE, convert_crs = FALSE, crs = NULL, ...){
   if (!grepl("\\.geojson$", file)) {
     file <- paste0(file, ".geojson")
   }
   file <- path.expand(file)
   destpath <- dirname(file)
   if (!file.exists(destpath)) dir.create(destpath)
-  write_ogr(input, tempfile(), file, precision, overwrite, ...)
+  write_ogr(input, tempfile(), file, precision, overwrite, 
+            convert_crs = convert_crs, crs = crs, ...)
 }
 
-write_ogr <- function(input, dir, file, precision = NULL, overwrite, ...){
+write_ogr <- function(input, dir, file, precision = NULL, overwrite, 
+                      convert_crs = FALSE, crs = NULL, ...){
+  
+  if (convert_crs) {
+    input <- convert_crs(input, crs = crs)
+  }
+  
   input@data <- convert_ordered(input@data)
   dots <- list(...)
   if (!is.null(precision)) {
@@ -300,7 +308,8 @@ convert_ordered <- function(df) {
   return(df)
 }
 
-geojson_rw <- function(input, target = c("char", "list"), ...){
+geojson_rw <- function(input, target = c("char", "list"), 
+                       convert_crs = FALSE, crs = NULL, ...){
 
   read_fun <- switch(target, 
                      char = geojson_file_to_char, 
@@ -308,12 +317,14 @@ geojson_rw <- function(input, target = c("char", "list"), ...){
   
   if (inherits(input, "SpatialCollections")) {
     tmp <- tempfile(fileext = ".geojson")
-    tmp2 <- suppressMessages(geojson_write(input, file = tmp))
+    tmp2 <- suppressMessages(geojson_write(input, file = tmp, 
+                                           convert_crs = convert_crs, crs = crs))
     paths <- vapply(tg_compact(tmp2), "[[", "", "path")
     lapply(paths, read_fun, ...)
   } else {
     tmp <- tempfile(fileext = ".geojson")
-    suppressMessages(geojson_write(input, file = tmp))
+    suppressMessages(geojson_write(input, file = tmp, 
+                                   convert_crs = convert_crs, crs = crs))
     read_fun(tmp, ...)
   }
 }

--- a/man/geojson_json.Rd
+++ b/man/geojson_json.Rd
@@ -5,7 +5,8 @@
 \title{Convert many input types with spatial data to geojson specified as a json string}
 \usage{
 geojson_json(input, lat = NULL, lon = NULL, group = NULL,
-  geometry = "point", type = "FeatureCollection", ...)
+  geometry = "point", type = "FeatureCollection", convert_crs = FALSE,
+  crs = NULL, ...)
 }
 \arguments{
 \item{input}{Input list, data.frame, spatial class, or sf class. Inputs can also be dplyr \code{tbl_df}
@@ -21,6 +22,10 @@ apply for points}
 \item{geometry}{(character) One of point (Default) or polygon.}
 
 \item{type}{(character)The type of collection. One of FeatureCollection (default) or GeometryCollection.}
+
+\item{convert_crs}{Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.}
+
+\item{crs}{The CRS of the input if it is not already defined. For \code{sf} objects this can be an epsg code as a four or five digit integer or a valid proj4 string. For \code{Spatial} obects it must be a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.}
 
 \item{...}{Further args passed on to \code{\link[jsonlite]{toJSON}}}
 }

--- a/man/geojson_json.Rd
+++ b/man/geojson_json.Rd
@@ -25,7 +25,7 @@ apply for points}
 
 \item{convert_crs}{Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.}
 
-\item{crs}{The CRS of the input if it is not already defined. For \code{sf} objects this can be an epsg code as a four or five digit integer or a valid proj4 string. For \code{Spatial} obects it must be a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.}
+\item{crs}{The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.}
 
 \item{...}{Further args passed on to \code{\link[jsonlite]{toJSON}}}
 }

--- a/man/geojson_json.Rd
+++ b/man/geojson_json.Rd
@@ -5,7 +5,7 @@
 \title{Convert many input types with spatial data to geojson specified as a json string}
 \usage{
 geojson_json(input, lat = NULL, lon = NULL, group = NULL,
-  geometry = "point", type = "FeatureCollection", convert_crs = FALSE,
+  geometry = "point", type = "FeatureCollection", convert_wgs84 = FALSE,
   crs = NULL, ...)
 }
 \arguments{
@@ -23,9 +23,9 @@ apply for points}
 
 \item{type}{(character)The type of collection. One of FeatureCollection (default) or GeometryCollection.}
 
-\item{convert_crs}{Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.}
+\item{convert_wgs84}{Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.}
 
-\item{crs}{The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.}
+\item{crs}{The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_wgs84} is \code{FALSE} or the object already has a CRS.}
 
 \item{...}{Further args passed on to \code{\link[jsonlite]{toJSON}}}
 }

--- a/man/geojson_list.Rd
+++ b/man/geojson_list.Rd
@@ -5,7 +5,7 @@
 \title{Convert many input types with spatial data to geojson specified as a list}
 \usage{
 geojson_list(input, lat = NULL, lon = NULL, group = NULL,
-  geometry = "point", type = "FeatureCollection", convert_crs = FALSE,
+  geometry = "point", type = "FeatureCollection", convert_wgs84 = FALSE,
   crs = NULL, ...)
 }
 \arguments{
@@ -24,9 +24,9 @@ for points}
 \item{type}{(character) The type of collection. One of FeatureCollection (default) or
 GeometryCollection.}
 
-\item{convert_crs}{Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.}
+\item{convert_wgs84}{Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.}
 
-\item{crs}{The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.}
+\item{crs}{The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_wgs84} is \code{FALSE} or the object already has a CRS.}
 
 \item{...}{Ignored}
 }

--- a/man/geojson_list.Rd
+++ b/man/geojson_list.Rd
@@ -26,7 +26,7 @@ GeometryCollection.}
 
 \item{convert_crs}{Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.}
 
-\item{crs}{The CRS of the input if it is not already defined. For \code{sf} objects this can be an epsg code as a four or five digit integer or a valid proj4 string. For \code{Spatial} obects it must be a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.}
+\item{crs}{The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.}
 
 \item{...}{Ignored}
 }

--- a/man/geojson_list.Rd
+++ b/man/geojson_list.Rd
@@ -5,7 +5,8 @@
 \title{Convert many input types with spatial data to geojson specified as a list}
 \usage{
 geojson_list(input, lat = NULL, lon = NULL, group = NULL,
-  geometry = "point", type = "FeatureCollection", ...)
+  geometry = "point", type = "FeatureCollection", convert_crs = FALSE,
+  crs = NULL, ...)
 }
 \arguments{
 \item{input}{Input list, data.frame, spatial class, or sf class. Inputs can also be dplyr \code{tbl_df}
@@ -22,6 +23,10 @@ for points}
 
 \item{type}{(character) The type of collection. One of FeatureCollection (default) or
 GeometryCollection.}
+
+\item{convert_crs}{Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.}
+
+\item{crs}{The CRS of the input if it is not already defined. For \code{sf} objects this can be an epsg code as a four or five digit integer or a valid proj4 string. For \code{Spatial} obects it must be a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.}
 
 \item{...}{Ignored}
 }

--- a/man/geojson_write.Rd
+++ b/man/geojson_write.Rd
@@ -6,7 +6,7 @@
 \usage{
 geojson_write(input, lat = NULL, lon = NULL, geometry = "point",
   group = NULL, file = "myfile.geojson", overwrite = TRUE,
-  precision = NULL, ...)
+  precision = NULL, convert_crs = FALSE, crs = NULL, ...)
 }
 \arguments{
 \item{input}{Input list, data.frame, spatial class, or sf class. Inputs can also be
@@ -34,6 +34,10 @@ the file already exists, we stop with error message.}
 \item{precision}{desired number of decimal places for the coordinates in the
 geojson file. Using fewer decimal places can decrease file sizes (at the
 cost of precision).}
+
+\item{convert_crs}{Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.}
+
+\item{crs}{The CRS of the input if it is not already defined. For \code{sf} objects this can be an epsg code as a four or five digit integer or a valid proj4 string. For \code{Spatial} obects it must be a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.}
 
 \item{...}{Further args passed on to \code{\link[rgdal]{writeOGR}}}
 }

--- a/man/geojson_write.Rd
+++ b/man/geojson_write.Rd
@@ -6,7 +6,7 @@
 \usage{
 geojson_write(input, lat = NULL, lon = NULL, geometry = "point",
   group = NULL, file = "myfile.geojson", overwrite = TRUE,
-  precision = NULL, convert_crs = FALSE, crs = NULL, ...)
+  precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...)
 }
 \arguments{
 \item{input}{Input list, data.frame, spatial class, or sf class. Inputs can also be
@@ -35,9 +35,9 @@ the file already exists, we stop with error message.}
 geojson file. Using fewer decimal places can decrease file sizes (at the
 cost of precision).}
 
-\item{convert_crs}{Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.}
+\item{convert_wgs84}{Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.}
 
-\item{crs}{The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.}
+\item{crs}{The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_wgs84} is \code{FALSE} or the object already has a CRS.}
 
 \item{...}{Further args passed on to \code{\link[rgdal]{writeOGR}}}
 }

--- a/man/geojson_write.Rd
+++ b/man/geojson_write.Rd
@@ -37,7 +37,7 @@ cost of precision).}
 
 \item{convert_crs}{Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate referece system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude unitsof decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.}
 
-\item{crs}{The CRS of the input if it is not already defined. For \code{sf} objects this can be an epsg code as a four or five digit integer or a valid proj4 string. For \code{Spatial} obects it must be a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.}
+\item{crs}{The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_crs} is \code{FALSE} or the object already has a CRS.}
 
 \item{...}{Further args passed on to \code{\link[rgdal]{writeOGR}}}
 }

--- a/tests/testthat/test-crs_convert.R
+++ b/tests/testthat/test-crs_convert.R
@@ -102,29 +102,29 @@ test_that("geojson_list: convert_crs works with sf classes", {
 })
 
 test_that("geojson_json: convert_crs works with Spatial classes", {
-  expect_equal(jsonlite::fromJSON(geojson_json(spdf_4326, convert_crs = TRUE)), 
-               jsonlite::fromJSON(geojson_json(spdf_4326, convert_crs = FALSE)))
-  expect_equal(jsonlite::fromJSON(geojson_json(spdf_4326)), 
-               jsonlite::fromJSON(geojson_json(spdf_3005, convert_crs = TRUE)))
+  expect_equal(geojson_list(geojson_json(spdf_4326, convert_crs = TRUE)), 
+               geojson_list(geojson_json(spdf_4326, convert_crs = FALSE)))
+  expect_equal(geojson_list(geojson_json(spdf_4326)), 
+               geojson_list(geojson_json(spdf_3005, convert_crs = TRUE)))
   proj4string(spdf_3005) <- NA_character_
-  expect_equal(jsonlite::fromJSON(geojson_json(spdf_4326)), 
-               jsonlite::fromJSON(geojson_json(spdf_3005, 
+  expect_equal(geojson_list(geojson_json(spdf_4326)), 
+               geojson_list(geojson_json(spdf_3005, 
                                                convert_crs = TRUE, 
                                                crs = "+init=epsg:3005")))
-  expect_equal(jsonlite::fromJSON(geojson_json(spdf_4326)), 
-               jsonlite::fromJSON(geojson_json(spdf_3005, convert_crs = TRUE, crs = 3005)))
+  expect_equal(geojson_list(geojson_json(spdf_4326)), 
+               geojson_list(geojson_json(spdf_3005, convert_crs = TRUE, crs = 3005)))
 })
 
 test_that("geojson_json: convert_crs works with sf classes", {
   expect_equal(geojson_json(sf_4326, convert_crs = TRUE), 
                geojson_json(sf_4326, convert_crs = FALSE))
-  expect_equal(jsonlite::fromJSON(geojson_json(sf_4326)), 
-               jsonlite::fromJSON(geojson_json(sf_3005, convert_crs = TRUE)))
+  expect_equal(geojson_list(geojson_json(sf_4326)), 
+               geojson_list(geojson_json(sf_3005, convert_crs = TRUE)))
   st_crs(sf_3005) <- NA_crs_
-  expect_equal(jsonlite::fromJSON(geojson_json(sf_4326)), 
-               jsonlite::fromJSON(geojson_json(sf_3005, 
+  expect_equal(geojson_list(geojson_json(sf_4326)), 
+               geojson_list(geojson_json(sf_3005, 
                                                convert_crs = TRUE, 
                                                crs = "+init=epsg:3005")))
-  expect_equal(jsonlite::fromJSON(geojson_json(sf_4326)), 
-               jsonlite::fromJSON(geojson_json(sf_3005, convert_crs = TRUE, crs = 3005)))
+  expect_equal(geojson_list(geojson_json(sf_4326)), 
+               geojson_list(geojson_json(sf_3005, convert_crs = TRUE, crs = 3005)))
 })

--- a/tests/testthat/test-crs_convert.R
+++ b/tests/testthat/test-crs_convert.R
@@ -1,25 +1,39 @@
-library(sf)
+context("detect and convert crs")
+suppressPackageStartupMessages(library(sf))
+suppressPackageStartupMessages(library(sp))
+
 sfc <-  st_sfc(st_point(c(0,0)), st_point(c(1,1)))
 sf <-  st_sf(a = 1:2, geom = sfc)
-st_crs(sf) <-  4326
-detect_convert_crs(sf)
-
-st_crs(sf) <- 3005
-detect_convert_crs(sf)
-
-st_crs(sfc) <- 4326
-detect_convert_crs(sfc)
-
-st_crs(sfc) <- 3005
-detect_convert_crs(sfc)
-
-library(sp)
 pts = cbind(1:5, 1:5)
 df = data.frame(a = 1:5)
-
 spdf <- SpatialPointsDataFrame(pts, df)
-proj4string(spdf) <- CRS("+init=epsg:4326")
-detect_convert_crs(spdf)
 
-proj4string(spdf) <- CRS("+init=epsg:3005")
-detect_convert_crs(spdf)
+test_that("works with sf", {
+  suppressWarnings(st_crs(sf) <-  4326)
+  expect_equal(st_crs(detect_convert_crs(sf))[["proj4string"]],
+               "+proj=longlat +datum=WGS84 +no_defs")
+  
+  suppressWarnings(st_crs(sf) <- 3005)
+  expect_equal(st_crs(detect_convert_crs(sf))[["proj4string"]],
+               "+proj=longlat +datum=WGS84 +no_defs")
+})
+
+test_that("works with sf", {
+  suppressWarnings(st_crs(sfc) <-  4326)
+  expect_equal(st_crs(detect_convert_crs(sfc))[["proj4string"]],
+               "+proj=longlat +datum=WGS84 +no_defs")
+  
+  suppressWarnings(st_crs(sfc) <- 3005)
+  expect_equal(st_crs(detect_convert_crs(sfc))[["proj4string"]],
+               "+proj=longlat +datum=WGS84 +no_defs")
+})
+
+test_that("works with spatial", {
+suppressWarnings(proj4string(spdf) <- CRS("+init=epsg:4326"))
+expect_equal(proj4string(detect_convert_crs(spdf)), 
+             "+init=epsg:4326 +proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0")
+
+suppressWarnings(proj4string(spdf) <- CRS("+init=epsg:3005"))
+expect_equal(proj4string(detect_convert_crs(spdf)), 
+             "+init=epsg:4326 +proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0")
+})

--- a/tests/testthat/test-crs_convert.R
+++ b/tests/testthat/test-crs_convert.R
@@ -1,6 +1,7 @@
 context("detect and convert crs")
 suppressPackageStartupMessages(library(sf))
 suppressPackageStartupMessages(library(sp))
+library(jsonlite)
 
 sfc <-  st_sfc(st_point(c(0,0)), st_point(c(1,1)))
 sf <-  st_sf(a = 1:2, geom = sfc)
@@ -101,25 +102,29 @@ test_that("geojson_list: convert_crs works with sf classes", {
 })
 
 test_that("geojson_json: convert_crs works with Spatial classes", {
-  expect_equal(geojson_json(spdf_4326, convert_crs = TRUE), 
-               geojson_json(spdf_4326, convert_crs = FALSE))
-  expect_equal(geojson_json(spdf_4326), 
-               geojson_json(spdf_3005, convert_crs = TRUE))
+  expect_equal(jsonlite::fromJSON(geojson_json(spdf_4326, convert_crs = TRUE)), 
+               jsonlite::fromJSON(geojson_json(spdf_4326, convert_crs = FALSE)))
+  expect_equal(jsonlite::fromJSON(geojson_json(spdf_4326)), 
+               jsonlite::fromJSON(geojson_json(spdf_3005, convert_crs = TRUE)))
   proj4string(spdf_3005) <- NA_character_
-  expect_equal(geojson_json(spdf_4326), 
-               geojson_json(spdf_3005, convert_crs = TRUE, crs = "+init=epsg:3005"))
-  expect_equal(geojson_json(spdf_4326), 
-               geojson_json(spdf_3005, convert_crs = TRUE, crs = 3005))
+  expect_equal(jsonlite::fromJSON(geojson_json(spdf_4326)), 
+               jsonlite::fromJSON(geojson_json(spdf_3005, 
+                                               convert_crs = TRUE, 
+                                               crs = "+init=epsg:3005")))
+  expect_equal(jsonlite::fromJSON(geojson_json(spdf_4326)), 
+               jsonlite::fromJSON(geojson_json(spdf_3005, convert_crs = TRUE, crs = 3005)))
 })
 
 test_that("geojson_json: convert_crs works with sf classes", {
   expect_equal(geojson_json(sf_4326, convert_crs = TRUE), 
                geojson_json(sf_4326, convert_crs = FALSE))
-  expect_equal(geojson_json(sf_4326), 
-               geojson_json(sf_3005, convert_crs = TRUE))
+  expect_equal(jsonlite::fromJSON(geojson_json(sf_4326)), 
+               jsonlite::fromJSON(geojson_json(sf_3005, convert_crs = TRUE)))
   st_crs(sf_3005) <- NA_crs_
-  expect_equal(geojson_json(sf_4326), 
-               geojson_json(sf_3005, convert_crs = TRUE, crs = "+init=epsg:3005"))
-  expect_equal(geojson_json(sf_4326), 
-               geojson_json(sf_3005, convert_crs = TRUE, crs = 3005))
+  expect_equal(jsonlite::fromJSON(geojson_json(sf_4326)), 
+               jsonlite::fromJSON(geojson_json(sf_3005, 
+                                               convert_crs = TRUE, 
+                                               crs = "+init=epsg:3005")))
+  expect_equal(jsonlite::fromJSON(geojson_json(sf_4326)), 
+               jsonlite::fromJSON(geojson_json(sf_3005, convert_crs = TRUE, crs = 3005)))
 })

--- a/tests/testthat/test-crs_convert.R
+++ b/tests/testthat/test-crs_convert.R
@@ -1,0 +1,25 @@
+library(sf)
+sfc <-  st_sfc(st_point(c(0,0)), st_point(c(1,1)))
+sf <-  st_sf(a = 1:2, geom = sfc)
+st_crs(sf) <-  4326
+detect_convert_crs(sf)
+
+st_crs(sf) <- 3005
+detect_convert_crs(sf)
+
+st_crs(sfc) <- 4326
+detect_convert_crs(sfc)
+
+st_crs(sfc) <- 3005
+detect_convert_crs(sfc)
+
+library(sp)
+pts = cbind(1:5, 1:5)
+df = data.frame(a = 1:5)
+
+spdf <- SpatialPointsDataFrame(pts, df)
+proj4string(spdf) <- CRS("+init=epsg:4326")
+detect_convert_crs(spdf)
+
+proj4string(spdf) <- CRS("+init=epsg:3005")
+detect_convert_crs(spdf)

--- a/tests/testthat/test-crs_convert.R
+++ b/tests/testthat/test-crs_convert.R
@@ -76,7 +76,7 @@ test_that("is_wgs84 works with Spatial", {
   expect_warning(is_wgs84(spdf_3005), "WGS84")
 })
 
-test_that("convert_crs works with Spatial classes", {
+test_that("geojson_list: convert_crs works with Spatial classes", {
   expect_equal(geojson_list(spdf_4326, convert_crs = TRUE), 
                geojson_list(spdf_4326, convert_crs = FALSE))
   expect_equal(geojson_list(spdf_4326), 
@@ -88,7 +88,7 @@ test_that("convert_crs works with Spatial classes", {
                geojson_list(spdf_3005, convert_crs = TRUE, crs = 3005))
 })
 
-test_that("convert_crs works with sf classes", {
+test_that("geojson_list: convert_crs works with sf classes", {
   expect_equal(geojson_list(sf_4326, convert_crs = TRUE), 
                geojson_list(sf_4326, convert_crs = FALSE))
   expect_equal(geojson_list(sf_4326), 
@@ -98,4 +98,28 @@ test_that("convert_crs works with sf classes", {
                geojson_list(sf_3005, convert_crs = TRUE, crs = "+init=epsg:3005"))
   expect_equal(geojson_list(sf_4326), 
                geojson_list(sf_3005, convert_crs = TRUE, crs = 3005))
+})
+
+test_that("geojson_json: convert_crs works with Spatial classes", {
+  expect_equal(geojson_json(spdf_4326, convert_crs = TRUE), 
+               geojson_json(spdf_4326, convert_crs = FALSE))
+  expect_equal(geojson_json(spdf_4326), 
+               geojson_json(spdf_3005, convert_crs = TRUE))
+  proj4string(spdf_3005) <- NA_character_
+  expect_equal(geojson_json(spdf_4326), 
+               geojson_json(spdf_3005, convert_crs = TRUE, crs = "+init=epsg:3005"))
+  expect_equal(geojson_json(spdf_4326), 
+               geojson_json(spdf_3005, convert_crs = TRUE, crs = 3005))
+})
+
+test_that("geojson_json: convert_crs works with sf classes", {
+  expect_equal(geojson_json(sf_4326, convert_crs = TRUE), 
+               geojson_json(sf_4326, convert_crs = FALSE))
+  expect_equal(geojson_json(sf_4326), 
+               geojson_json(sf_3005, convert_crs = TRUE))
+  st_crs(sf_3005) <- NA_crs_
+  expect_equal(geojson_json(sf_4326), 
+               geojson_json(sf_3005, convert_crs = TRUE, crs = "+init=epsg:3005"))
+  expect_equal(geojson_json(sf_4326), 
+               geojson_json(sf_3005, convert_crs = TRUE, crs = 3005))
 })

--- a/tests/testthat/test-crs_convert.R
+++ b/tests/testthat/test-crs_convert.R
@@ -116,8 +116,8 @@ test_that("geojson_json: convert_crs works with Spatial classes", {
 })
 
 test_that("geojson_json: convert_crs works with sf classes", {
-  expect_equal(geojson_json(sf_4326, convert_crs = TRUE), 
-               geojson_json(sf_4326, convert_crs = FALSE))
+  expect_equal(geojson_list(geojson_json(sf_4326, convert_crs = TRUE)), 
+                            geojson_list(geojson_json(sf_4326, convert_crs = FALSE)))
   expect_equal(geojson_list(geojson_json(sf_4326)), 
                geojson_list(geojson_json(sf_3005, convert_crs = TRUE)))
   st_crs(sf_3005) <- NA_crs_
@@ -127,4 +127,34 @@ test_that("geojson_json: convert_crs works with sf classes", {
                                                crs = "+init=epsg:3005")))
   expect_equal(geojson_list(geojson_json(sf_4326)), 
                geojson_list(geojson_json(sf_3005, convert_crs = TRUE, crs = 3005)))
+})
+
+file_list <- function(x) geojson_read(x$path, method = "local", what = "list")
+
+test_that("geojson_write: convert_crs works with Spatial classes", {
+  expect_equal(file_list(geojson_write(spdf_4326, convert_crs = TRUE)), 
+               file_list(geojson_write(spdf_4326, convert_crs = FALSE)))
+  expect_equal(file_list(geojson_write(spdf_4326)), 
+               file_list(geojson_write(spdf_3005, convert_crs = TRUE)))
+  proj4string(spdf_3005) <- NA_character_
+  expect_equal(file_list(geojson_write(spdf_4326)), 
+               file_list(geojson_write(spdf_3005, 
+                                         convert_crs = TRUE, 
+                                         crs = "+init=epsg:3005")))
+  expect_equal(file_list(geojson_write(spdf_4326)), 
+               file_list(geojson_write(spdf_3005, convert_crs = TRUE, crs = 3005)))
+})
+
+test_that("geojson_write: convert_crs works with sf classes", {
+  expect_equal(file_list(geojson_write(sf_4326, convert_crs = TRUE)), 
+                         file_list(geojson_write(sf_4326, convert_crs = FALSE)))
+  expect_equal(file_list(geojson_write(sf_4326)), 
+               file_list(geojson_write(sf_3005, convert_crs = TRUE)))
+  st_crs(sf_3005) <- NA_crs_
+  expect_equal(file_list(geojson_write(sf_4326)), 
+               file_list(geojson_write(sf_3005, 
+                                         convert_crs = TRUE, 
+                                         crs = "+init=epsg:3005")))
+  expect_equal(file_list(geojson_write(sf_4326)), 
+               file_list(geojson_write(sf_3005, convert_crs = TRUE, crs = 3005)))
 })

--- a/tests/testthat/test-crs_convert.R
+++ b/tests/testthat/test-crs_convert.R
@@ -1,7 +1,6 @@
 context("detect and convert crs")
 suppressPackageStartupMessages(library(sf))
 suppressPackageStartupMessages(library(sp))
-library(jsonlite)
 
 sfc <-  st_sfc(st_point(c(0,0)), st_point(c(1,1)))
 sf <-  st_sf(a = 1:2, geom = sfc)
@@ -15,43 +14,43 @@ proj4string(spdf_4326) <- CRS("+init=epsg:4326")
 spdf_3005 <- spTransform(spdf_4326, CRS("+init=epsg:3005"))
 
 test_that("works with sf", {
-  expect_equal(st_crs(convert_crs(sf_4326))[["proj4string"]],
+  expect_equal(st_crs(convert_wgs84(sf_4326))[["proj4string"]],
                "+proj=longlat +datum=WGS84 +no_defs")
   
-  expect_equal(st_crs(convert_crs(sf_3005))[["proj4string"]],
+  expect_equal(st_crs(convert_wgs84(sf_3005))[["proj4string"]],
                "+proj=longlat +datum=WGS84 +no_defs")
 })
 
 test_that("works with sfc", {
   suppressWarnings(st_crs(sfc) <-  4326)
-  expect_equal(st_crs(convert_crs(sfc))[["proj4string"]],
+  expect_equal(st_crs(convert_wgs84(sfc))[["proj4string"]],
                "+proj=longlat +datum=WGS84 +no_defs")
   
   suppressWarnings(st_crs(sfc) <- 3005)
-  expect_equal(st_crs(convert_crs(sfc))[["proj4string"]],
+  expect_equal(st_crs(convert_wgs84(sfc))[["proj4string"]],
                "+proj=longlat +datum=WGS84 +no_defs")
 })
 
 test_that("works with spatial", {
-  expect_equal(proj4string(convert_crs(spdf_4326)), 
+  expect_equal(proj4string(convert_wgs84(spdf_4326)), 
                "+init=epsg:4326 +proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0")
 
-  expect_equal(proj4string(convert_crs(spdf_3005)), 
+  expect_equal(proj4string(convert_wgs84(spdf_3005)), 
                "+init=epsg:4326 +proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0")
 })
 
 test_that("allows supplying a CRS with Spatial", {
-  expect_equal(proj4string(convert_crs(spdf, crs = "+init=epsg:3005")), 
+  expect_equal(proj4string(convert_wgs84(spdf, crs = "+init=epsg:3005")), 
                "+init=epsg:4326 +proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0")
 })
 
 test_that("allows supplying a CRS with sf", {
-  expect_equal(st_crs(convert_crs(sf, crs = 3005))[["proj4string"]], 
+  expect_equal(st_crs(convert_wgs84(sf, crs = 3005))[["proj4string"]], 
                "+proj=longlat +datum=WGS84 +no_defs")
 })
 
 test_that("allows supplying a CRS with sfc", {
-  expect_equal(st_crs(convert_crs(sfc, crs = 3005))[["proj4string"]], 
+  expect_equal(st_crs(convert_wgs84(sfc, crs = 3005))[["proj4string"]], 
                "+proj=longlat +datum=WGS84 +no_defs")
 })
 
@@ -77,84 +76,84 @@ test_that("is_wgs84 works with Spatial", {
   expect_warning(is_wgs84(spdf_3005), "WGS84")
 })
 
-test_that("geojson_list: convert_crs works with Spatial classes", {
-  expect_equal(geojson_list(spdf_4326, convert_crs = TRUE), 
-               geojson_list(spdf_4326, convert_crs = FALSE))
+test_that("geojson_list: convert_wgs84 works with Spatial classes", {
+  expect_equal(geojson_list(spdf_4326, convert_wgs84 = TRUE), 
+               geojson_list(spdf_4326, convert_wgs84 = FALSE))
   expect_equal(geojson_list(spdf_4326), 
-               geojson_list(spdf_3005, convert_crs = TRUE))
+               geojson_list(spdf_3005, convert_wgs84 = TRUE))
   proj4string(spdf_3005) <- NA_character_
   expect_equal(geojson_list(spdf_4326), 
-               geojson_list(spdf_3005, convert_crs = TRUE, crs = "+init=epsg:3005"))
+               geojson_list(spdf_3005, convert_wgs84 = TRUE, crs = "+init=epsg:3005"))
   expect_equal(geojson_list(spdf_4326), 
-               geojson_list(spdf_3005, convert_crs = TRUE, crs = 3005))
+               geojson_list(spdf_3005, convert_wgs84 = TRUE, crs = 3005))
 })
 
-test_that("geojson_list: convert_crs works with sf classes", {
-  expect_equal(geojson_list(sf_4326, convert_crs = TRUE), 
-               geojson_list(sf_4326, convert_crs = FALSE))
+test_that("geojson_list: convert_wgs84 works with sf classes", {
+  expect_equal(geojson_list(sf_4326, convert_wgs84 = TRUE), 
+               geojson_list(sf_4326, convert_wgs84 = FALSE))
   expect_equal(geojson_list(sf_4326), 
-               geojson_list(sf_3005, convert_crs = TRUE))
+               geojson_list(sf_3005, convert_wgs84 = TRUE))
   st_crs(sf_3005) <- NA_crs_
   expect_equal(geojson_list(sf_4326), 
-               geojson_list(sf_3005, convert_crs = TRUE, crs = "+init=epsg:3005"))
+               geojson_list(sf_3005, convert_wgs84 = TRUE, crs = "+init=epsg:3005"))
   expect_equal(geojson_list(sf_4326), 
-               geojson_list(sf_3005, convert_crs = TRUE, crs = 3005))
+               geojson_list(sf_3005, convert_wgs84 = TRUE, crs = 3005))
 })
 
-test_that("geojson_json: convert_crs works with Spatial classes", {
-  expect_equal(geojson_list(geojson_json(spdf_4326, convert_crs = TRUE)), 
-               geojson_list(geojson_json(spdf_4326, convert_crs = FALSE)))
+test_that("geojson_json: convert_wgs84 works with Spatial classes", {
+  expect_equal(geojson_list(geojson_json(spdf_4326, convert_wgs84 = TRUE)), 
+               geojson_list(geojson_json(spdf_4326, convert_wgs84 = FALSE)))
   expect_equal(geojson_list(geojson_json(spdf_4326)), 
-               geojson_list(geojson_json(spdf_3005, convert_crs = TRUE)))
+               geojson_list(geojson_json(spdf_3005, convert_wgs84 = TRUE)))
   proj4string(spdf_3005) <- NA_character_
   expect_equal(geojson_list(geojson_json(spdf_4326)), 
                geojson_list(geojson_json(spdf_3005, 
-                                               convert_crs = TRUE, 
+                                               convert_wgs84 = TRUE, 
                                                crs = "+init=epsg:3005")))
   expect_equal(geojson_list(geojson_json(spdf_4326)), 
-               geojson_list(geojson_json(spdf_3005, convert_crs = TRUE, crs = 3005)))
+               geojson_list(geojson_json(spdf_3005, convert_wgs84 = TRUE, crs = 3005)))
 })
 
-test_that("geojson_json: convert_crs works with sf classes", {
-  expect_equal(geojson_list(geojson_json(sf_4326, convert_crs = TRUE)), 
-                            geojson_list(geojson_json(sf_4326, convert_crs = FALSE)))
+test_that("geojson_json: convert_wgs84 works with sf classes", {
+  expect_equal(geojson_list(geojson_json(sf_4326, convert_wgs84 = TRUE)), 
+                            geojson_list(geojson_json(sf_4326, convert_wgs84 = FALSE)))
   expect_equal(geojson_list(geojson_json(sf_4326)), 
-               geojson_list(geojson_json(sf_3005, convert_crs = TRUE)))
+               geojson_list(geojson_json(sf_3005, convert_wgs84 = TRUE)))
   st_crs(sf_3005) <- NA_crs_
   expect_equal(geojson_list(geojson_json(sf_4326)), 
                geojson_list(geojson_json(sf_3005, 
-                                               convert_crs = TRUE, 
+                                               convert_wgs84 = TRUE, 
                                                crs = "+init=epsg:3005")))
   expect_equal(geojson_list(geojson_json(sf_4326)), 
-               geojson_list(geojson_json(sf_3005, convert_crs = TRUE, crs = 3005)))
+               geojson_list(geojson_json(sf_3005, convert_wgs84 = TRUE, crs = 3005)))
 })
 
 file_to_list <- function(x) geojson_read(x$path, method = "local", what = "list")
 
-test_that("geojson_write: convert_crs works with Spatial classes", {
-  expect_equal(file_to_list(geojson_write(spdf_4326, convert_crs = TRUE)), 
-               file_to_list(geojson_write(spdf_4326, convert_crs = FALSE)))
+test_that("geojson_write: convert_wgs84 works with Spatial classes", {
+  expect_equal(file_to_list(geojson_write(spdf_4326, convert_wgs84 = TRUE)), 
+               file_to_list(geojson_write(spdf_4326, convert_wgs84 = FALSE)))
   expect_equal(file_to_list(geojson_write(spdf_4326)), 
-               file_to_list(geojson_write(spdf_3005, convert_crs = TRUE)))
+               file_to_list(geojson_write(spdf_3005, convert_wgs84 = TRUE)))
   proj4string(spdf_3005) <- NA_character_
   expect_equal(file_to_list(geojson_write(spdf_4326)), 
                file_to_list(geojson_write(spdf_3005, 
-                                         convert_crs = TRUE, 
+                                         convert_wgs84 = TRUE, 
                                          crs = "+init=epsg:3005")))
   expect_equal(file_to_list(geojson_write(spdf_4326)), 
-               file_to_list(geojson_write(spdf_3005, convert_crs = TRUE, crs = 3005)))
+               file_to_list(geojson_write(spdf_3005, convert_wgs84 = TRUE, crs = 3005)))
 })
 
-test_that("geojson_write: convert_crs works with sf classes", {
-  expect_equal(file_to_list(geojson_write(sf_4326, convert_crs = TRUE)), 
-               file_to_list(geojson_write(sf_4326, convert_crs = FALSE)))
+test_that("geojson_write: convert_wgs84 works with sf classes", {
+  expect_equal(file_to_list(geojson_write(sf_4326, convert_wgs84 = TRUE)), 
+               file_to_list(geojson_write(sf_4326, convert_wgs84 = FALSE)))
   expect_equal(file_to_list(geojson_write(sf_4326)), 
-               file_to_list(geojson_write(sf_3005, convert_crs = TRUE)))
+               file_to_list(geojson_write(sf_3005, convert_wgs84 = TRUE)))
   st_crs(sf_3005) <- NA_crs_
   expect_equal(file_to_list(geojson_write(sf_4326)), 
                file_to_list(geojson_write(sf_3005, 
-                                         convert_crs = TRUE, 
+                                         convert_wgs84 = TRUE, 
                                          crs = "+init=epsg:3005")))
   expect_equal(file_to_list(geojson_write(sf_4326)), 
-               file_to_list(geojson_write(sf_3005, convert_crs = TRUE, crs = 3005)))
+               file_to_list(geojson_write(sf_3005, convert_wgs84 = TRUE, crs = 3005)))
 })

--- a/tests/testthat/test-crs_convert.R
+++ b/tests/testthat/test-crs_convert.R
@@ -39,17 +39,17 @@ test_that("works with spatial", {
 })
 
 test_that("allows supplying a CRS with Spatial", {
-  expect_equal(proj4string(convert_crs(spdf, init_crs = "+init=epsg:3005")), 
+  expect_equal(proj4string(convert_crs(spdf, crs = "+init=epsg:3005")), 
                "+init=epsg:4326 +proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0")
 })
 
 test_that("allows supplying a CRS with sf", {
-  expect_equal(st_crs(convert_crs(sf, init_crs = 3005))[["proj4string"]], 
+  expect_equal(st_crs(convert_crs(sf, crs = 3005))[["proj4string"]], 
                "+proj=longlat +datum=WGS84 +no_defs")
 })
 
 test_that("allows supplying a CRS with sfc", {
-  expect_equal(st_crs(convert_crs(sfc, init_crs = 3005))[["proj4string"]], 
+  expect_equal(st_crs(convert_crs(sfc, crs = 3005))[["proj4string"]], 
                "+proj=longlat +datum=WGS84 +no_defs")
 })
 

--- a/tests/testthat/test-crs_convert.R
+++ b/tests/testthat/test-crs_convert.R
@@ -10,30 +10,69 @@ spdf <- SpatialPointsDataFrame(pts, df)
 
 test_that("works with sf", {
   suppressWarnings(st_crs(sf) <-  4326)
-  expect_equal(st_crs(detect_convert_crs(sf))[["proj4string"]],
+  expect_equal(st_crs(convert_crs(sf))[["proj4string"]],
                "+proj=longlat +datum=WGS84 +no_defs")
   
   suppressWarnings(st_crs(sf) <- 3005)
-  expect_equal(st_crs(detect_convert_crs(sf))[["proj4string"]],
+  expect_equal(st_crs(convert_crs(sf))[["proj4string"]],
                "+proj=longlat +datum=WGS84 +no_defs")
 })
 
 test_that("works with sf", {
   suppressWarnings(st_crs(sfc) <-  4326)
-  expect_equal(st_crs(detect_convert_crs(sfc))[["proj4string"]],
+  expect_equal(st_crs(convert_crs(sfc))[["proj4string"]],
                "+proj=longlat +datum=WGS84 +no_defs")
   
   suppressWarnings(st_crs(sfc) <- 3005)
-  expect_equal(st_crs(detect_convert_crs(sfc))[["proj4string"]],
+  expect_equal(st_crs(convert_crs(sfc))[["proj4string"]],
                "+proj=longlat +datum=WGS84 +no_defs")
 })
 
 test_that("works with spatial", {
-suppressWarnings(proj4string(spdf) <- CRS("+init=epsg:4326"))
-expect_equal(proj4string(detect_convert_crs(spdf)), 
-             "+init=epsg:4326 +proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0")
+  suppressWarnings(proj4string(spdf) <- CRS("+init=epsg:4326"))
+  expect_equal(proj4string(convert_crs(spdf)), 
+               "+init=epsg:4326 +proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0")
+  
+  suppressWarnings(proj4string(spdf) <- CRS("+init=epsg:3005"))
+  expect_equal(proj4string(convert_crs(spdf)), 
+               "+init=epsg:4326 +proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0")
+})
 
-suppressWarnings(proj4string(spdf) <- CRS("+init=epsg:3005"))
-expect_equal(proj4string(detect_convert_crs(spdf)), 
-             "+init=epsg:4326 +proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0")
+test_that("allows supplying a CRS with Spatial", {
+  expect_equal(proj4string(convert_crs(spdf, init_crs = "+init=epsg:3005")), 
+               "+init=epsg:4326 +proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0")
+})
+
+test_that("allows supplying a CRS with sf", {
+  expect_equal(st_crs(convert_crs(sf, init_crs = 3005))[["proj4string"]], 
+               "+proj=longlat +datum=WGS84 +no_defs")
+})
+
+test_that("allows supplying a CRS with sfc", {
+  expect_equal(st_crs(convert_crs(sfc, init_crs = 3005))[["proj4string"]], 
+               "+proj=longlat +datum=WGS84 +no_defs")
+})
+
+test_that("is_wgs84 works with sf", {
+  st_crs(sf) <- 4326
+  expect_true(is_wgs84(sf))
+  sf_3005 <- st_transform(sf, 3005)
+  expect_false(suppressWarnings(is_wgs84(sf_3005)))
+  expect_warning(is_wgs84(sf_3005), "WGS84")
+})
+
+test_that("is_wgs84 works with sfc", {
+  st_crs(sfc) <- 4326
+  expect_true(is_wgs84(sfc))
+  sfc_3005 <- st_transform(sfc, 3005)
+  expect_false(suppressWarnings(is_wgs84(sfc_3005)))
+  expect_warning(is_wgs84(sfc_3005), "WGS84")
+})
+
+test_that("is_wgs84 works with Spatial", {
+  proj4string(spdf) <- "+init=epsg:4326"
+  expect_true(is_wgs84(spdf))
+  spdf_3005 <- spTransform(spdf, "+init=epsg:3005")
+  expect_false(suppressWarnings(is_wgs84(spdf_3005)))
+  expect_warning(is_wgs84(spdf_3005), "WGS84")
 })

--- a/tests/testthat/test-crs_convert.R
+++ b/tests/testthat/test-crs_convert.R
@@ -129,32 +129,32 @@ test_that("geojson_json: convert_crs works with sf classes", {
                geojson_list(geojson_json(sf_3005, convert_crs = TRUE, crs = 3005)))
 })
 
-file_list <- function(x) geojson_read(x$path, method = "local", what = "list")
+file_to_list <- function(x) geojson_read(x$path, method = "local", what = "list")
 
 test_that("geojson_write: convert_crs works with Spatial classes", {
-  expect_equal(file_list(geojson_write(spdf_4326, convert_crs = TRUE)), 
-               file_list(geojson_write(spdf_4326, convert_crs = FALSE)))
-  expect_equal(file_list(geojson_write(spdf_4326)), 
-               file_list(geojson_write(spdf_3005, convert_crs = TRUE)))
+  expect_equal(file_to_list(geojson_write(spdf_4326, convert_crs = TRUE)), 
+               file_to_list(geojson_write(spdf_4326, convert_crs = FALSE)))
+  expect_equal(file_to_list(geojson_write(spdf_4326)), 
+               file_to_list(geojson_write(spdf_3005, convert_crs = TRUE)))
   proj4string(spdf_3005) <- NA_character_
-  expect_equal(file_list(geojson_write(spdf_4326)), 
-               file_list(geojson_write(spdf_3005, 
+  expect_equal(file_to_list(geojson_write(spdf_4326)), 
+               file_to_list(geojson_write(spdf_3005, 
                                          convert_crs = TRUE, 
                                          crs = "+init=epsg:3005")))
-  expect_equal(file_list(geojson_write(spdf_4326)), 
-               file_list(geojson_write(spdf_3005, convert_crs = TRUE, crs = 3005)))
+  expect_equal(file_to_list(geojson_write(spdf_4326)), 
+               file_to_list(geojson_write(spdf_3005, convert_crs = TRUE, crs = 3005)))
 })
 
 test_that("geojson_write: convert_crs works with sf classes", {
-  expect_equal(file_list(geojson_write(sf_4326, convert_crs = TRUE)), 
-                         file_list(geojson_write(sf_4326, convert_crs = FALSE)))
-  expect_equal(file_list(geojson_write(sf_4326)), 
-               file_list(geojson_write(sf_3005, convert_crs = TRUE)))
+  expect_equal(file_to_list(geojson_write(sf_4326, convert_crs = TRUE)), 
+               file_to_list(geojson_write(sf_4326, convert_crs = FALSE)))
+  expect_equal(file_to_list(geojson_write(sf_4326)), 
+               file_to_list(geojson_write(sf_3005, convert_crs = TRUE)))
   st_crs(sf_3005) <- NA_crs_
-  expect_equal(file_list(geojson_write(sf_4326)), 
-               file_list(geojson_write(sf_3005, 
+  expect_equal(file_to_list(geojson_write(sf_4326)), 
+               file_to_list(geojson_write(sf_3005, 
                                          convert_crs = TRUE, 
                                          crs = "+init=epsg:3005")))
-  expect_equal(file_list(geojson_write(sf_4326)), 
-               file_list(geojson_write(sf_3005, convert_crs = TRUE, crs = 3005)))
+  expect_equal(file_to_list(geojson_write(sf_4326)), 
+               file_to_list(geojson_write(sf_3005, convert_crs = TRUE, crs = 3005)))
 })

--- a/tests/testthat/test-sf_classes.R
+++ b/tests/testthat/test-sf_classes.R
@@ -6,16 +6,9 @@ testfc <- st_read(file, quiet = TRUE)
 
 test_that("fc utility functions work", {
   expect_equal(get_sf_column_name(testfc), "geometry")
-  expect_true(is_wgs84(testfc))
   
   expect_equal(get_geometry_type(testfc$geometry), "GEOMETRY")
   expect_equal(switch_geom_type(get_geometry_type(testfc$geometry)), "GeometryCollection")
-  
-  testfc_3005 <- st_transform(testfc, 3005)
-  expect_false(suppressWarnings(is_wgs84(testfc_3005)))
-  expect_warning(is_wgs84(testfc_3005), "WGS84")
-  # expect_message(detect_convert_crs(testfc_3005), "EPSG:3005 to WGS84")
-  # expect_true(is_wgs84(suppressMessages(detect_convert_crs(testfc_3005))))
 })
 
 ## POINT

--- a/tests/testthat/test-sf_classes.R
+++ b/tests/testthat/test-sf_classes.R
@@ -5,8 +5,6 @@ file <- system.file("examples", "feature_collection.geojson", package = "geojson
 testfc <- st_read(file, quiet = TRUE)
 
 test_that("fc utility functions work", {
-  expect_equal(get_epsg(testfc), 4326)
-  expect_equal(get_epsg(testfc$geometry), 4326)
   expect_equal(get_sf_column_name(testfc), "geometry")
   expect_true(is_wgs84(testfc))
   

--- a/tests/testthat/test-sf_classes.R
+++ b/tests/testthat/test-sf_classes.R
@@ -1,5 +1,5 @@
 context("sf classes")
-suppressPackageStartupMessages(library(sf, quietly = TRUE))
+suppressPackageStartupMessages(library(sf))
 
 file <- system.file("examples", "feature_collection.geojson", package = "geojsonio")
 testfc <- st_read(file, quiet = TRUE)

--- a/tests/testthat/test-spatial_methods.R
+++ b/tests/testthat/test-spatial_methods.R
@@ -1,7 +1,7 @@
 context("spatial-methods")
 
-library("sp")
-library("rgeos")
+suppressPackageStartupMessages(library("sp"))
+suppressPackageStartupMessages(library("rgeos"))
 
 sp_poly <- local({
   poly1 <- Polygons(list(Polygon(cbind(c(-100,-90,-85,-100),


### PR DESCRIPTION
As per discussion in #101, this adds two additional arguments to `geojson_list`, `geojson_json`, and `geojson_write`:

- `convert_wgs84`: convert the object to WGS84 CRS to conform to the GeoJSON standard. Default `FALSE`
- `crs`: a user can assign a CRS (via a EPSG code or a proj4string) to an object that does not have one, to allow it to be converted to WGS84. Default `NULL`

This only works on `Spatial` and `sf[c]` objects.

I didn't write tests for all of the different `Spatial` classes as they all use the same pattern, but wrote tests for `geojson_list`, `geojson_json`, and `geojson_write` for basic `sf` and `Spatial` objects.