### PR TITLE
Allow to convert to other types, including auto

### DIFF
--- a/R/geojson_json.R
+++ b/R/geojson_json.R
@@ -7,7 +7,8 @@
 #' @param lat (character) Latitude name. The default is \code{NULL}, and we attempt to guess.
 #' @param lon (character) Longitude name. The default is \code{NULL}, and we attempt to guess.
 #' @param geometry (character) One of point (Default) or polygon.
-#' @param type  (character)The type of collection. One of FeatureCollection (default) or GeometryCollection. 
+#' @param type  (character) The type of collection. One of 'auto' (default for 'sf' objects), 
+#' 'FeatureCollection' (default for everything else), or 'GeometryCollection'. 
 #' This is ignored for \code{Spatial} objects as it will always produce a "FeatureCollection"
 #' @param group (character) A grouping variable to perform grouping for polygons - doesn't
 #' apply for points
@@ -298,21 +299,21 @@ geojson_json.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL,
 
 #' @export
 geojson_json.sf <- function(input, lat = NULL, lon = NULL, group = NULL,
-                            geometry = "point",  type='FeatureCollection',
+                            geometry = "point",  type='auto',
                             convert_wgs84 = FALSE, crs = NULL, ...) {
   geoclass(as.json(geojson_list(input, convert_wgs84 = convert_wgs84, crs = crs), ...), type)
 }
 
 #' @export
 geojson_json.sfc <- function(input, lat = NULL, lon = NULL, group = NULL,
-                             geometry = "point",  type='FeatureCollection',
+                             geometry = "point",  type='auto',
                              convert_wgs84 = FALSE, crs = NULL, ...) {
   geoclass(as.json(geojson_list(input, convert_wgs84 = convert_wgs84, crs = crs), ...), type)
 }
 
 #' @export
 geojson_json.sfg <- function(input, lat = NULL, lon = NULL, group = NULL,
-                             geometry = "point",  type='FeatureCollection',
+                             geometry = "point",  type='auto',
                              convert_wgs84 = FALSE, crs = NULL, ...) {
   geoclass(as.json(geojson_list(input), ...), type)
 }
@@ -362,7 +363,7 @@ geojson_json.data.frame <- function(input, lat = NULL, lon = NULL, group = NULL,
 
 #' @export
 geojson_json.list <- function(input, lat = NULL, lon = NULL, group = NULL,
-                              geometry = "point",  type='FeatureCollection', ...){
+                              geometry = "point", type='FeatureCollection', ...){
   if (geometry == "polygon") lint_polygon_list(input)
   tmp <- if (!is.named(input)) {
     list(lon = NULL, lat = NULL)

--- a/R/geojson_json.R
+++ b/R/geojson_json.R
@@ -7,7 +7,8 @@
 #' @param lat (character) Latitude name. The default is \code{NULL}, and we attempt to guess.
 #' @param lon (character) Longitude name. The default is \code{NULL}, and we attempt to guess.
 #' @param geometry (character) One of point (Default) or polygon.
-#' @param type  (character)The type of collection. One of FeatureCollection (default) or GeometryCollection.
+#' @param type  (character)The type of collection. One of FeatureCollection (default) or GeometryCollection. 
+#' This is ignored for \code{Spatial} objects as it will always produce a "FeatureCollection"
 #' @param group (character) A grouping variable to perform grouping for polygons - doesn't
 #' apply for points
 #' @param convert_wgs84 Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate reference system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude units of decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.
@@ -221,7 +222,7 @@ geojson_json <- function(input, lat = NULL, lon = NULL, group = NULL,
 geojson_json.SpatialPolygons <- function(input, lat = NULL, lon = NULL, group = NULL,
                                          geometry = "point",  type='FeatureCollection',
                                          convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
 }
 
 #' @export
@@ -229,7 +230,7 @@ geojson_json.SpatialPolygonsDataFrame <- function(input, lat = NULL, lon = NULL,
                                                   group = NULL, geometry = "point",
                                                   type='FeatureCollection',
                                                   convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
 }
 
 #' @export
@@ -237,7 +238,7 @@ geojson_json.SpatialPoints <- function(input, lat = NULL, lon = NULL, group = NU
                                        geometry = "point",  type='FeatureCollection',
                                        convert_wgs84 = FALSE, crs = NULL, ...) {
   dat <- SpatialPointsDataFrame(input, data.frame(dat = 1:NROW(input@coords)))
-  geoclass(geojson_rw(dat, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type)
+  geoclass(geojson_rw(dat, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
 }
 
 #' @export
@@ -245,14 +246,14 @@ geojson_json.SpatialPointsDataFrame <- function(input, lat = NULL, lon = NULL,
                                                 group = NULL, geometry = "point",
                                                 type='FeatureCollection',
                                                 convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
 }
 
 #' @export
 geojson_json.SpatialLines <- function(input, lat = NULL, lon = NULL, group = NULL,
                                       geometry = "point",  type='FeatureCollection',
                                       convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
 }
 
 #' @export
@@ -260,14 +261,14 @@ geojson_json.SpatialLinesDataFrame <- function(input, lat = NULL, lon = NULL,
                                                group = NULL, geometry = "point",
                                                type='FeatureCollection',
                                                convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
 }
 
 #' @export
 geojson_json.SpatialGrid <- function(input, lat = NULL, lon = NULL, group = NULL,
                                      geometry = "point",  type='FeatureCollection',
                                      convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
 }
 
 #' @export
@@ -275,14 +276,14 @@ geojson_json.SpatialGridDataFrame <- function(input, lat = NULL, lon = NULL,
                                               group = NULL, geometry = "point",
                                               type='FeatureCollection',
                                               convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
 }
 
 #' @export
 geojson_json.SpatialPixels <- function(input, lat = NULL, lon = NULL, group = NULL,
                                        geometry = "point",  type='FeatureCollection',
                                        convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
 }
 
 #' @export
@@ -290,7 +291,7 @@ geojson_json.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL,
                                                 group = NULL, geometry = "point",
                                                 type='FeatureCollection',
                                                 convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
 }
 
 # sf classes ---------------------------------
@@ -321,7 +322,7 @@ geojson_json.sfg <- function(input, lat = NULL, lon = NULL, group = NULL,
 geojson_json.SpatialRings <- function(input, lat = NULL, lon = NULL, group = NULL,
                                       geometry = "point",  type='FeatureCollection',
                                       convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
 }
 
 #' @export
@@ -329,7 +330,7 @@ geojson_json.SpatialRingsDataFrame <- function(input, lat = NULL, lon = NULL,
                                                group = NULL, geometry = "point",
                                                type='FeatureCollection',
                                                convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
 }
 
 #' @export
@@ -340,7 +341,7 @@ geojson_json.SpatialCollections <- function(input, lat = NULL, lon = NULL,
   lapply(
     geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs, ...),
     geoclass,
-    type = type
+    type = 'FeatureCollection'
   )
 }
 

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -10,10 +10,17 @@ class_json <- function(x, ..., type = "FeatureCollection") {
 }
 
 geoclass <- function(x, type = "FeatureCollection") {
-  res <- switch(
-    type,
-    FeatureCollection = geojson::featurecollection(unclass(x)),
-    GeometryCollection = geojson::geometrycollection(unclass(x))
+  res <- switch(type,
+    "auto" = geojson::to_geojson(unclass(x)),
+    "Point" = geojson::point(unclass(x)),
+    "LineString" = geojson::linestring(unclass(x)),
+    "Polygon" = geojson::polygon(unclass(x)),
+    "MultiPoint" = geojson::multipoint(unclass(x)),
+    "MultiLineString" = geojson::multilinestring(unclass(x)),
+    "MultiPolygon" = geojson::multipolygon(unclass(x)),
+    "Feature" = geojson::feature(unclass(x)),
+    "FeatureCollection" = geojson::featurecollection(unclass(x)),
+    "GeometryCollection" = geojson::geometrycollection(unclass(x))
   )
   class(res) <- c(class(res), c("geo_json", "json"))
   return(res)

--- a/man/geojson_json.Rd
+++ b/man/geojson_json.Rd
@@ -21,7 +21,8 @@ apply for points}
 
 \item{geometry}{(character) One of point (Default) or polygon.}
 
-\item{type}{(character)The type of collection. One of FeatureCollection (default) or GeometryCollection. 
+\item{type}{(character) The type of collection. One of 'auto' (default for 'sf' objects), 
+'FeatureCollection' (default for everything else), or 'GeometryCollection'. 
 This is ignored for \code{Spatial} objects as it will always produce a "FeatureCollection"}
 
 \item{convert_wgs84}{Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate reference system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude units of decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.}

--- a/man/geojson_json.Rd
+++ b/man/geojson_json.Rd
@@ -21,7 +21,8 @@ apply for points}
 
 \item{geometry}{(character) One of point (Default) or polygon.}
 
-\item{type}{(character)The type of collection. One of FeatureCollection (default) or GeometryCollection.}
+\item{type}{(character)The type of collection. One of FeatureCollection (default) or GeometryCollection. 
+This is ignored for \code{Spatial} objects as it will always produce a "FeatureCollection"}
 
 \item{convert_wgs84}{Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate reference system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude units of decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.}
 

--- a/man/topojson_json.Rd
+++ b/man/topojson_json.Rd
@@ -22,7 +22,8 @@ apply for points}
 
 \item{geometry}{(character) One of point (Default) or polygon.}
 
-\item{type}{(character)The type of collection. One of FeatureCollection (default) or GeometryCollection.}
+\item{type}{(character)The type of collection. One of FeatureCollection (default) or GeometryCollection. 
+This is ignored for \code{Spatial} objects as it will always produce a "FeatureCollection"}
 
 \item{convert_wgs84}{Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate reference system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude units of decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.}
 

--- a/man/topojson_json.Rd
+++ b/man/topojson_json.Rd
@@ -22,7 +22,8 @@ apply for points}
 
 \item{geometry}{(character) One of point (Default) or polygon.}
 
-\item{type}{(character)The type of collection. One of FeatureCollection (default) or GeometryCollection. 
+\item{type}{(character) The type of collection. One of 'auto' (default for 'sf' objects), 
+'FeatureCollection' (default for everything else), or 'GeometryCollection'. 
 This is ignored for \code{Spatial} objects as it will always produce a "FeatureCollection"}
 
 \item{convert_wgs84}{Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate reference system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude units of decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.}

--- a/tests/testthat/test-sf_classes.R
+++ b/tests/testthat/test-sf_classes.R
@@ -57,10 +57,10 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
     pt_sf_json <- geojson_json(pt_sf)
 
     expect_equal(un_class(pt_sfg_json),
-                 "{ \"type\": \"FeatureCollection\", \"features\": [{\"type\":\"Point\",\"coordinates\":[3.2,4]}] }")
+                 "{\"type\":\"Point\",\"coordinates\":[3.2,4]}")
 
     expect_equal(un_class(pt_sfc_json),
-                 "{ \"type\": \"FeatureCollection\", \"features\": [{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"Point\",\"coordinates\":[3.2,4]},{\"type\":\"Point\",\"coordinates\":[3,4.6]},{\"type\":\"Point\",\"coordinates\":[3.8,4.4]}]}] }")
+                 "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"Point\",\"coordinates\":[3.2,4]},{\"type\":\"Point\",\"coordinates\":[3,4.6]},{\"type\":\"Point\",\"coordinates\":[3.8,4.4]}]}")
 
     expect_equal(un_class(pt_sf_json),
                  "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[3.2,4]}},{\"type\":\"Feature\",\"properties\":{\"x\":\"b\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[3,4.6]}},{\"type\":\"Feature\",\"properties\":{\"x\":\"c\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[3.8,4.4]}}]}")
@@ -92,10 +92,10 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
     expect_s3_class(mp_sf_json, "geojson")
 
     expect_equal(un_class(mp_sfg_json),
-                 "{ \"type\": \"FeatureCollection\", \"features\": [{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]}] }")
+                 "{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]}")
 
     expect_equal(un_class(mp_sfc_json),
-                 "{ \"type\": \"FeatureCollection\", \"features\": [{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]}] }")
+                 "{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]}")
 
     expect_equal(un_class(mp_sf_json),
                  "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]}}]}")
@@ -128,10 +128,10 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
     expect_s3_class(pol_sf_json, "geojson")
 
     expect_equal(un_class(pol_sfg_json),
-                 "{ \"type\": \"FeatureCollection\", \"features\": [{\"type\":\"Polygon\",\"coordinates\":[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]]}] }")
+                 "{\"type\":\"Polygon\",\"coordinates\":[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]]}")
 
     expect_equal(un_class(pol_sfc_json),
-                 "{ \"type\": \"FeatureCollection\", \"features\": [{\"type\":\"Polygon\",\"coordinates\":[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]]}] }")
+                 "{\"type\":\"Polygon\",\"coordinates\":[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]]}")
 
     expect_equal(un_class(pol_sf_json),
                  "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]]}}]}")
@@ -165,10 +165,10 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
     expect_s3_class(mpol_sf_json, "geojson")
 
     expect_equal(un_class(mpol_sfg_json),
-                 "{ \"type\": \"FeatureCollection\", \"features\": [{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]}] }")
+                 "{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]}")
 
     expect_equal(un_class(mpol_sfc_json),
-                 "{ \"type\": \"FeatureCollection\", \"features\": [{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]}] }")
+                 "{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]}")
 
     expect_equal(un_class(mpol_sf_json),
                  "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]}}]}")
@@ -203,10 +203,10 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
     expect_s3_class(ls_sf_json, "geojson")
 
     expect_equal(un_class(ls_sfg_json),
-                 "{ \"type\": \"FeatureCollection\", \"features\": [{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}] }")
+                 "{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}")
 
     expect_equal(un_class(ls_sfc_json),
-                 "{ \"type\": \"FeatureCollection\", \"features\": [{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}] }")
+                 "{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}")
 
     expect_equal(un_class(ls_sf_json),
                  "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}}]}")
@@ -240,10 +240,10 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
     expect_s3_class(mls_sf_json, "geojson")
 
     expect_equal(un_class(mls_sfg_json),
-                 "{ \"type\": \"FeatureCollection\", \"features\": [{\"type\":\"MultiLineString\",\"coordinates\":[[[0,3],[0,4],[1,5],[2,5]],[[0.2,3],[0.2,4],[1,4.8],[2,4.8]],[[0,4.4],[0.6,5]]]}] }")
+                 "{\"type\":\"MultiLineString\",\"coordinates\":[[[0,3],[0,4],[1,5],[2,5]],[[0.2,3],[0.2,4],[1,4.8],[2,4.8]],[[0,4.4],[0.6,5]]]}")
 
     expect_equal(un_class(mls_sfc_json),
-                 "{ \"type\": \"FeatureCollection\", \"features\": [{\"type\":\"MultiLineString\",\"coordinates\":[[[0,3],[0,4],[1,5],[2,5]],[[0.2,3],[0.2,4],[1,4.8],[2,4.8]],[[0,4.4],[0.6,5]]]}] }")
+                 "{\"type\":\"MultiLineString\",\"coordinates\":[[[0,3],[0,4],[1,5],[2,5]],[[0.2,3],[0.2,4],[1,4.8],[2,4.8]],[[0,4.4],[0.6,5]]]}")
 
     expect_equal(un_class(mls_sf_json),
                  "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"MultiLineString\",\"coordinates\":[[[0,3],[0,4],[1,5],[2,5]],[[0.2,3],[0.2,4],[1,4.8],[2,4.8]],[[0,4.4],[0.6,5]]]}}]}")
@@ -275,10 +275,10 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
     expect_s3_class(gc_sf_json, "geojson")
 
     expect_equal(un_class(gc_sfg_json),
-                 "{ \"type\": \"FeatureCollection\", \"features\": [{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]},{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]},{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}]}] }")
+                 "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]},{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]},{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}]}")
 
     expect_equal(un_class(gc_sfc_json),
-                 "{ \"type\": \"FeatureCollection\", \"features\": [{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]},{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]},{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}]}] }")
+                 "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]},{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]},{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}]}")
 
     expect_equal(un_class(gc_sf_json),
                  "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]},{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]},{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}]}}]}")
@@ -297,6 +297,10 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
                           st_point, dim = "XYZM")
     pt_sfc_xyzm <- st_sfc(p_list_xyzm)
     pt_sf_xyzm <- st_sf(x = c("a", "b", "c"), pt_sfc_xyzm)
+
+
+
+    expect_equal
   })
 
   test_that("Deal with M dimensions: multipoint", {
@@ -309,10 +313,10 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
     out <- geojson_list(mp_sf)
     expect_equal(dim(out$features[[1]]$geometry$coordinates), c(6, 3))
   })
-
+  
   test_that("sf columns of class units are processed as numeric", {
     pol_sf$area <- structure(rep(1, nrow(pol_sf)), class = "units")
-
+    
     expect_s3_class(geojson_json(pol_sf), "geojson")
     expect_equal(read_sf(geojson_json(pol_sf))[["area"]], as.numeric(pol_sf$area))
   })

--- a/tests/testthat/test-sf_classes.R
+++ b/tests/testthat/test-sf_classes.R
@@ -297,10 +297,6 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
                           st_point, dim = "XYZM")
     pt_sfc_xyzm <- st_sfc(p_list_xyzm)
     pt_sf_xyzm <- st_sf(x = c("a", "b", "c"), pt_sfc_xyzm)
-
-
-
-    expect_equal
   })
 
   test_that("Deal with M dimensions: multipoint", {


### PR DESCRIPTION
Not ready for merge.

Right now we currently only support FeatureCollection and GeometryCollection, but there's no reason we couldn't expand that. I started on this by modifying the `geoclass` function to accept all types, including `'auto'` using the new [`geojson::to_geojson`](https://github.com/ropensci/geojson/pull/29) function.

This looks like it works well for `sf` and `Spatial` objects, but to implement for other classes will need more work to accommodate the different types. `num_to_geo_list` and `list_to_geo_list` will need to be modified at the very least. Or we could (temporarily?) restrict the `geojson_json` methods for `list`, `data.frame`, and `numeric` to deal only support FeatureCollection and GeometryCollection as they do now, and kick this one down the road...