### PR TITLE
Fix small typo on topojson_write

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -233,7 +233,7 @@ topojson_list(s)
 ```{r}
 library('maps')
 data(us.cities)
-geojson_write(us.cities[1:2, ], lat = 'lat', lon = 'long')
+topojson_write(us.cities[1:2, ], lat = 'lat', lon = 'long')
 ```
 
 ### Read TopoJSON

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ topojson_list(s)
 ```r
 library('maps')
 data(us.cities)
-geojson_write(us.cities[1:2, ], lat = 'lat', lon = 'long')
+topojson_write(us.cities[1:2, ], lat = 'lat', lon = 'long')
 #> <geojson-file>
 #>   Path:       myfile.geojson
 #>   From class: data.frame

--- a/README.md
+++ b/README.md
@@ -303,8 +303,8 @@ topojson_list(s)
 library('maps')
 data(us.cities)
 topojson_write(us.cities[1:2, ], lat = 'lat', lon = 'long')
-#> <geojson-file>
-#>   Path:       myfile.geojson
+#> <topojson-file>
+#>   Path:       myfile.json
 #>   From class: data.frame
 ```
 


### PR DESCRIPTION
## Description
There's a small typo on the README regarding the usage of topojson_write. It should be topojson_write instead of geojson_write.

Thanks for such a great project ✨
