### PR TITLE
Skip geoclass

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Convert data to 'GeoJSON' or 'TopoJSON' from various R classes,
     'geojsonio' does not aim to replace packages like 'sp', 'rgdal', 'rgeos',
     but rather aims to be a high level client to simplify conversions of data
     from and to 'GeoJSON' and 'TopoJSON'.
-Version: 0.5.0
+Version: 0.5.0.9310
 License: MIT + file LICENSE
 Authors@R: c(
     person("Scott", "Chamberlain", role = c("aut", "cre"), email = "myrmecocystus@gmail.com"),

--- a/R/geojson_json.R
+++ b/R/geojson_json.R
@@ -255,7 +255,8 @@ geojson_json <- function(input, lat = NULL, lon = NULL, group = NULL,
 geojson_json.SpatialPolygons <- function(input, lat = NULL, lon = NULL, group = NULL,
                                          geometry = "point",  type='FeatureCollection',
                                          convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
+  check_type_sp(type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = type)
 }
 
 #' @export
@@ -263,15 +264,17 @@ geojson_json.SpatialPolygonsDataFrame <- function(input, lat = NULL, lon = NULL,
                                                   group = NULL, geometry = "point",
                                                   type='FeatureCollection',
                                                   convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
+  check_type_sp(type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = type)
 }
 
 #' @export
 geojson_json.SpatialPoints <- function(input, lat = NULL, lon = NULL, group = NULL,
                                        geometry = "point",  type='FeatureCollection',
                                        convert_wgs84 = FALSE, crs = NULL, ...) {
+  check_type_sp(type)
   dat <- SpatialPointsDataFrame(input, data.frame(dat = 1:NROW(input@coords)))
-  geoclass(geojson_rw(dat, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
+  geoclass(geojson_rw(dat, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = type)
 }
 
 #' @export
@@ -279,14 +282,16 @@ geojson_json.SpatialPointsDataFrame <- function(input, lat = NULL, lon = NULL,
                                                 group = NULL, geometry = "point",
                                                 type='FeatureCollection',
                                                 convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
+  check_type_sp(type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = type)
 }
 
 #' @export
 geojson_json.SpatialLines <- function(input, lat = NULL, lon = NULL, group = NULL,
                                       geometry = "point",  type='FeatureCollection',
                                       convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
+  check_type_sp(type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = type)
 }
 
 #' @export
@@ -294,14 +299,16 @@ geojson_json.SpatialLinesDataFrame <- function(input, lat = NULL, lon = NULL,
                                                group = NULL, geometry = "point",
                                                type='FeatureCollection',
                                                convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
+  check_type_sp(type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = type)
 }
 
 #' @export
 geojson_json.SpatialGrid <- function(input, lat = NULL, lon = NULL, group = NULL,
                                      geometry = "point",  type='FeatureCollection',
                                      convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
+  check_type_sp(type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = type)
 }
 
 #' @export
@@ -309,14 +316,16 @@ geojson_json.SpatialGridDataFrame <- function(input, lat = NULL, lon = NULL,
                                               group = NULL, geometry = "point",
                                               type='FeatureCollection',
                                               convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
+  check_type_sp(type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = type)
 }
 
 #' @export
 geojson_json.SpatialPixels <- function(input, lat = NULL, lon = NULL, group = NULL,
                                        geometry = "point",  type='FeatureCollection',
                                        convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
+  check_type_sp(type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = type)
 }
 
 #' @export
@@ -324,7 +333,8 @@ geojson_json.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL,
                                                 group = NULL, geometry = "point",
                                                 type='FeatureCollection',
                                                 convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
+  check_type_sp(type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = type)
 }
 
 # sf classes ---------------------------------
@@ -357,7 +367,8 @@ geojson_json.sfg <- function(input, lat = NULL, lon = NULL, group = NULL,
 geojson_json.SpatialRings <- function(input, lat = NULL, lon = NULL, group = NULL,
                                       geometry = "point",  type='FeatureCollection',
                                       convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
+  check_type_sp(type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = type)
 }
 
 #' @export
@@ -365,7 +376,8 @@ geojson_json.SpatialRingsDataFrame <- function(input, lat = NULL, lon = NULL,
                                                group = NULL, geometry = "point",
                                                type='FeatureCollection',
                                                convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = 'FeatureCollection')
+  check_type_sp(type)
+  geoclass(geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs), type = type)
 }
 
 #' @export
@@ -373,10 +385,11 @@ geojson_json.SpatialCollections <- function(input, lat = NULL, lon = NULL,
                                             group = NULL, geometry = "point",
                                             type='FeatureCollection',
                                             convert_wgs84 = FALSE, crs = NULL, ...) {
+  check_type_sp(type)
   lapply(
     geojson_rw(input, target = "char", convert_wgs84 = convert_wgs84, crs = crs, ...),
     geoclass,
-    type = 'FeatureCollection'
+    type = type
   )
 }
 
@@ -416,4 +429,9 @@ geojson_json.geo_list <- function(input, lat = NULL, lon = NULL, group = NULL,
                                   geometry = "point", type = "FeatureCollection", ...) {
 
   geoclass(to_json(input, ...), type)
+}
+
+check_type_sp <- function(x) {
+  types <- c('FeatureCollection', 'skip')
+  if (!x %in% types) stop("'type' must be one of: ", paste0(types, collapse=", "))
 }

--- a/R/geojson_json.R
+++ b/R/geojson_json.R
@@ -14,7 +14,9 @@
 #' for 'sf' objects),
 #' 'FeatureCollection' (default for everything else), or 'GeometryCollection'.
 #' This is ignored for \code{Spatial} objects as it will always produce a
-#' "FeatureCollection"
+#' "FeatureCollection". "skip" skips the coercion with package \pkg{geojson} 
+#' functions; skipping can save significant run time on larger geojson 
+#' objects
 #' @param group (character) A grouping variable to perform grouping for
 #' polygons - doesn't apply for points
 #' @param convert_wgs84 Should the input be converted to the
@@ -231,6 +233,16 @@
 #' ## Pretty print a json string
 #' geojson_json(c(-99.74,32.45))
 #' geojson_json(c(-99.74,32.45)) %>% pretty
+#' 
+#' # skipping the pretty geojson class coercion with the geojson pkg
+#' if (require(sf)) {
+#'   library(sf)
+#'   p1 <- rbind(c(0,0), c(1,0), c(3,2), c(2,4), c(1,4), c(0,0))
+#'   p2 <- rbind(c(5,5), c(5,6), c(4,5), c(5,5))
+#'   poly_sfc <- st_sfc(st_polygon(list(p1)), st_polygon(list(p2)))
+#'   geojson_json(poly_sfc)
+#'   geojson_json(poly_sfc, type = "skip")
+#' }
 #' }
 geojson_json <- function(input, lat = NULL, lon = NULL, group = NULL,
                          geometry = "point", type='FeatureCollection',
@@ -321,14 +333,16 @@ geojson_json.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL,
 geojson_json.sf <- function(input, lat = NULL, lon = NULL, group = NULL,
                             geometry = "point",  type='auto',
                             convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(as.json(geojson_list(input, convert_wgs84 = convert_wgs84, crs = crs), ...), type)
+  geoclass(
+    as.json(geojson_list(input, convert_wgs84 = convert_wgs84, crs = crs), ...), type)
 }
 
 #' @export
 geojson_json.sfc <- function(input, lat = NULL, lon = NULL, group = NULL,
                              geometry = "point",  type='auto',
                              convert_wgs84 = FALSE, crs = NULL, ...) {
-  geoclass(as.json(geojson_list(input, convert_wgs84 = convert_wgs84, crs = crs), ...), type)
+  geoclass(
+    as.json(geojson_list(input, convert_wgs84 = convert_wgs84, crs = crs), ...), type)
 }
 
 #' @export

--- a/R/geojson_json.R
+++ b/R/geojson_json.R
@@ -13,10 +13,9 @@
 #' @param type  (character) The type of collection. One of 'auto' (default
 #' for 'sf' objects),
 #' 'FeatureCollection' (default for everything else), or 'GeometryCollection'.
-#' This is ignored for \code{Spatial} objects as it will always produce a
-#' "FeatureCollection". "skip" skips the coercion with package \pkg{geojson} 
+#' "skip" skips the coercion with package \pkg{geojson} 
 #' functions; skipping can save significant run time on larger geojson 
-#' objects
+#' objects. \code{Spatial} objects can only accept "FeatureCollection" or "skip". 
 #' @param group (character) A grouping variable to perform grouping for
 #' polygons - doesn't apply for points
 #' @param convert_wgs84 Should the input be converted to the

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -20,7 +20,8 @@ geoclass <- function(x, type = "FeatureCollection") {
     "MultiPolygon" = geojson::multipolygon(unclass(x)),
     "Feature" = geojson::feature(unclass(x)),
     "FeatureCollection" = geojson::featurecollection(unclass(x)),
-    "GeometryCollection" = geojson::geometrycollection(unclass(x))
+    "GeometryCollection" = geojson::geometrycollection(unclass(x)),
+    "skip" = unclass(x)
   )
   class(res) <- c(class(res), c("geo_json", "json"))
   return(res)

--- a/man/geojson_json.Rd
+++ b/man/geojson_json.Rd
@@ -27,10 +27,9 @@ polygons - doesn't apply for points}
 \item{type}{(character) The type of collection. One of 'auto' (default
 for 'sf' objects),
 'FeatureCollection' (default for everything else), or 'GeometryCollection'.
-This is ignored for \code{Spatial} objects as it will always produce a
-"FeatureCollection". "skip" skips the coercion with package \pkg{geojson} 
+"skip" skips the coercion with package \pkg{geojson} 
 functions; skipping can save significant run time on larger geojson 
-objects}
+objects. \code{Spatial} objects can only accept "FeatureCollection" or "skip".}
 
 \item{convert_wgs84}{Should the input be converted to the
 \href{https://tools.ietf.org/html/rfc7946}{standard coordinate reference

--- a/man/geojson_json.Rd
+++ b/man/geojson_json.Rd
@@ -28,7 +28,9 @@ polygons - doesn't apply for points}
 for 'sf' objects),
 'FeatureCollection' (default for everything else), or 'GeometryCollection'.
 This is ignored for \code{Spatial} objects as it will always produce a
-"FeatureCollection"}
+"FeatureCollection". "skip" skips the coercion with package \pkg{geojson} 
+functions; skipping can save significant run time on larger geojson 
+objects}
 
 \item{convert_wgs84}{Should the input be converted to the
 \href{https://tools.ietf.org/html/rfc7946}{standard coordinate reference
@@ -253,5 +255,15 @@ if (require(sf)) {
 ## Pretty print a json string
 geojson_json(c(-99.74,32.45))
 geojson_json(c(-99.74,32.45)) \%>\% pretty
+
+# skipping the pretty geojson class coercion with the geojson pkg
+if (require(sf)) {
+  library(sf)
+  p1 <- rbind(c(0,0), c(1,0), c(3,2), c(2,4), c(1,4), c(0,0))
+  p2 <- rbind(c(5,5), c(5,6), c(4,5), c(5,5))
+  poly_sfc <- st_sfc(st_polygon(list(p1)), st_polygon(list(p2)))
+  geojson_json(poly_sfc)
+  geojson_json(poly_sfc, type = "skip")
+}
 }
 }

--- a/man/topojson_json.Rd
+++ b/man/topojson_json.Rd
@@ -27,10 +27,9 @@ polygons - doesn't apply for points}
 \item{type}{(character) The type of collection. One of 'auto' (default
 for 'sf' objects),
 'FeatureCollection' (default for everything else), or 'GeometryCollection'.
-This is ignored for \code{Spatial} objects as it will always produce a
-"FeatureCollection". "skip" skips the coercion with package \pkg{geojson} 
+"skip" skips the coercion with package \pkg{geojson} 
 functions; skipping can save significant run time on larger geojson 
-objects}
+objects. \code{Spatial} objects can only accept "FeatureCollection" or "skip".}
 
 \item{convert_wgs84}{Should the input be converted to the
 \href{https://tools.ietf.org/html/rfc7946}{standard coordinate reference

--- a/man/topojson_json.Rd
+++ b/man/topojson_json.Rd
@@ -28,7 +28,9 @@ polygons - doesn't apply for points}
 for 'sf' objects),
 'FeatureCollection' (default for everything else), or 'GeometryCollection'.
 This is ignored for \code{Spatial} objects as it will always produce a
-"FeatureCollection"}
+"FeatureCollection". "skip" skips the coercion with package \pkg{geojson} 
+functions; skipping can save significant run time on larger geojson 
+objects}
 
 \item{convert_wgs84}{Should the input be converted to the
 \href{https://tools.ietf.org/html/rfc7946}{standard coordinate reference

--- a/tests/testthat/test-geojson_json.R
+++ b/tests/testthat/test-geojson_json.R
@@ -104,3 +104,9 @@ test_that("geojson_json - acceptable type values for numeric/data.frame/list", {
   expect_error(geojson_json(us_cities[1:2,], type = "LineString"),
     "'type' must be one of")
 })
+
+test_that("skipping geoclass works with type = skip", {
+  x <- geojson_sp(geojson_json(c(-99.74,32.45)))
+  expect_match(attr(geojson_json(x), "type"), "FeatureCollection")
+  expect_null(attr(geojson_json(x, type = "skip"), "type"))
+})


### PR DESCRIPTION
Hi @sckott - again, hope you don't mind I jumped here. This (I think) completes fixing #128 by extending the ability to skip `geoclass` to Spatial objects, and adds tests.