### PR TITLE
quantization parameter in geo2topo

### DIFF
--- a/R/geo_topo.R
+++ b/R/geo_topo.R
@@ -8,6 +8,9 @@
 #' @param quantization (numeric) quantization parameter, use this to
 #'  quantize geometry prior to computing topology. Typical values are powers of 
 #'  ten (\code{1e4}, \code{1e5}, ...), default is \code{0} to not perform quantization.
+#'  For more information about quantization, see this 
+#'  \href{https://stackoverflow.com/questions/18900022/topojson-quantization-vs-simplification/18921214#18921214}{
+#'  StackOverflow post by Mike Bostock}.
 #' @param ... for \code{geo2topo} args passed  on to
 #' \code{\link[jsonlite]{fromJSON}}, and for \code{topo2geo} args passed  on to
 #' \code{\link[sf]{st_read}}

--- a/R/topojson_write.R
+++ b/R/topojson_write.R
@@ -8,6 +8,9 @@
 #' @param quantization (numeric) quantization parameter, use this to
 #'  quantize geometry prior to computing topology. Typical values are powers of 
 #'  ten (\code{1e4}, \code{1e5}, ...), default is \code{0} to not perform quantization.
+#'  For more information about quantization, see this 
+#'  \href{https://stackoverflow.com/questions/18900022/topojson-quantization-vs-simplification/18921214#18921214}{
+#'  StackOverflow post by Mike Bostock}.
 #' @return A \code{topojson_write} class, with two elements:
 #' \itemize{
 #'  \item path: path to the file with the TopoJSON

--- a/R/topojson_write.R
+++ b/R/topojson_write.R
@@ -398,7 +398,7 @@ topojson_write.list <- function(input, lat = NULL, lon = NULL, geometry="point",
 
   sp_helper(input, lat = lat, lon = lon, geometry = geometry, group = group,
             file = file, precision = precision, overwrite = overwrite,
-            class = "list", object_name = object_name, quantization, ...)
+            class = "list", object_name = object_name, quantization = quantization, ...)
 }
 
 #' @export
@@ -407,7 +407,7 @@ topojson_write.geo_list <- function(input, lat = NULL, lon = NULL, geometry = "p
   convert_wgs84 = FALSE, crs = NULL, object_name = "foo", quantization = 0, ...) {
 
   sp_helper(input, file = file, overwrite = overwrite, class = "geo_list", 
-    object_name = object_name, quantization, ...)
+    object_name = object_name, quantization = quantization, ...)
 }
 
 # JSON -----------------

--- a/R/topojson_write.R
+++ b/R/topojson_write.R
@@ -5,6 +5,9 @@
 #' @inheritParams geojson_write
 #' @param object_name (character) name to give to the TopoJSON object created.
 #' Default: "foo"
+#' @param quantization (numeric) quantization parameter, use this to
+#'  quantize geometry prior to computing topology. Typical values are powers of 
+#'  ten (\code{1e4}, \code{1e5}, ...), default is \code{0} to not perform quantization.
 #' @return A \code{topojson_write} class, with two elements:
 #' \itemize{
 #'  \item path: path to the file with the TopoJSON
@@ -181,7 +184,7 @@ topojson_write <- function(input, lat = NULL, lon = NULL, geometry = "point",
                            group = NULL, file = "myfile.topojson",
                            overwrite = TRUE, precision = NULL,
                            convert_wgs84 = FALSE, crs = NULL, 
-                           object_name = "foo", ...) {
+                           object_name = "foo", quantization = 0, ...) {
   UseMethod("topojson_write")
 }
 
@@ -191,7 +194,7 @@ topojson_write.default <- function(input, lat = NULL, lon = NULL, geometry = "po
                                            group = NULL, file = "myfile.topojson",
                                            overwrite = TRUE, precision = NULL,
                                            convert_wgs84 = FALSE, crs = NULL, 
-                                           object_name = "foo", ...) {
+                                           object_name = "foo", quantization = 0, ...) {
   stop("no 'topojson_write' method for ", class(input), call. = FALSE)
 }
 
@@ -200,11 +203,12 @@ topojson_write.SpatialPolygons <- function(input, lat = NULL, lon = NULL, geomet
                                            group = NULL, file = "myfile.topojson",
                                            overwrite = TRUE, precision = NULL,
                                            convert_wgs84 = FALSE, crs = NULL, 
-                                           object_name = "foo", ...) {
+                                           object_name = "foo", quantization = 0, ...) {
 
   sp_helper(input, file = file, precision = precision,
             convert_wgs84 = convert_wgs84, crs = crs,
-            class = "SpatialPolygons", object_name = object_name, ...)
+            class = "SpatialPolygons", object_name = object_name,
+            quantization = quantization, ...)
 }
 
 #' @export
@@ -212,11 +216,12 @@ topojson_write.SpatialPolygonsDataFrame <- function(input, lat = NULL, lon = NUL
                                                     group = NULL, file = "myfile.topojson",
                                                     overwrite = TRUE, precision = NULL,
                                                     convert_wgs84 = FALSE, crs = NULL, 
-                                                    object_name = "foo", ...) {
+                                                    object_name = "foo", quantization = 0, ...) {
 
   sp_helper(input, file = file, precision = precision,
             convert_wgs84 = convert_wgs84, crs = crs,
-            class = "SpatialPolygonsDataFrame", object_name = object_name, ...)
+            class = "SpatialPolygonsDataFrame", object_name = object_name, 
+            quantization = quantization, ...)
 }
 
 #' @export
@@ -224,11 +229,12 @@ topojson_write.SpatialPoints <- function(input, lat = NULL, lon = NULL, geometry
                                          group = NULL, file = "myfile.topojson",
                                          overwrite = TRUE, precision = NULL,
                                          convert_wgs84 = FALSE, crs = NULL, 
-                                         object_name = "foo", ...) {
+                                         object_name = "foo", quantization = 0, ...) {
 
   sp_helper(input, file = file, precision = precision,
             convert_wgs84 = convert_wgs84, crs = crs,
-            class = "SpatialPoints", object_name = object_name, ...)
+            class = "SpatialPoints", object_name = object_name, 
+            quantization = quantization, ...)
 }
 
 #' @export
@@ -236,11 +242,12 @@ topojson_write.SpatialPointsDataFrame <- function(input, lat = NULL, lon = NULL,
                                                   group = NULL, file = "myfile.topojson",
                                                   overwrite = TRUE, precision = NULL,
                                                   convert_wgs84 = FALSE, crs = NULL, 
-                                                  object_name = "foo", ...) {
+                                                  object_name = "foo", quantization = 0, ...) {
 
   sp_helper(input, file = file, precision = precision,
             convert_wgs84 = convert_wgs84, crs = crs,
-            class = "SpatialPointsDataFrame", object_name = object_name, ...)
+            class = "SpatialPointsDataFrame", object_name = object_name,
+            quantization = quantization, ...)
 }
 
 #' @export
@@ -248,11 +255,12 @@ topojson_write.SpatialLines <- function(input, lat = NULL, lon = NULL, geometry 
                                         group = NULL, file = "myfile.topojson",
                                         overwrite = TRUE, precision = NULL,
                                         convert_wgs84 = FALSE, crs = NULL, 
-                                        object_name = "foo", ...) {
+                                        object_name = "foo", quantization = 0, ...) {
 
   sp_helper(input, file = file, precision = precision,
             convert_wgs84 = convert_wgs84, crs = crs,
-            class = "SpatialLines", object_name = object_name, ...)
+            class = "SpatialLines", object_name = object_name,
+            quantization = quantization, ...)
 }
 
 #' @export
@@ -260,32 +268,35 @@ topojson_write.SpatialLinesDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                  group = NULL, file = "myfile.topojson",
                                                  overwrite = TRUE, precision = NULL,
                                                  convert_wgs84 = FALSE, crs = NULL, 
-                                                 object_name = "foo", ...) {
+                                                 object_name = "foo", quantization = 0, ...) {
 
   sp_helper(input, file = file, precision = precision,
             convert_wgs84 = convert_wgs84, crs = crs,
-            class = "SpatialLinesDataFrame", object_name = object_name, ...)
+            class = "SpatialLinesDataFrame", object_name = object_name, 
+            quantization = quantization, ...)
 }
 
 #' @export
 topojson_write.SpatialGrid <- function(input, lat = NULL, lon = NULL, geometry = "point",
   group = NULL, file = "myfile.topojson", overwrite = TRUE, precision = NULL,
-  convert_wgs84 = FALSE, crs = NULL, object_name = "foo", ...) {
+  convert_wgs84 = FALSE, crs = NULL, object_name = "foo", quantization = 0, ...) {
 
   sp_helper(input, file = file, precision = precision,
             convert_wgs84 = convert_wgs84, crs = crs,
-            class = "SpatialGrid", object_name = object_name, ...)
+            class = "SpatialGrid", object_name = object_name, 
+            quantization = quantization, ...)
 }
 
 #' @export
 topojson_write.SpatialGridDataFrame <- function(input, lat = NULL, lon = NULL,
   geometry = "point", group = NULL, file = "myfile.topojson",
   overwrite = TRUE, precision = NULL, convert_wgs84 = FALSE, crs = NULL, 
-  object_name = "foo", ...) {
+  object_name = "foo", quantization = 0, ...) {
 
   sp_helper(input, file = file, precision = precision,
             convert_wgs84 = convert_wgs84, crs = crs,
-            class = "SpatialGridDataFrame", object_name = object_name, ...)
+            class = "SpatialGridDataFrame", object_name = object_name, 
+            quantization = quantization, ...)
 }
 
 #' @export
@@ -293,11 +304,12 @@ topojson_write.SpatialPixels <- function(input, lat = NULL, lon = NULL, geometry
                                         group = NULL, file = "myfile.topojson",
                                         overwrite = TRUE, precision = NULL,
                                         convert_wgs84 = FALSE, crs = NULL, 
-                                        object_name = "foo", ...) {
+                                        object_name = "foo", quantization = 0, ...) {
 
   sp_helper(input, file = file, precision = precision,
             convert_wgs84 = convert_wgs84, crs = crs,
-            class = "SpatialPixelsDataFrame", object_name = object_name, ...)
+            class = "SpatialPixelsDataFrame", object_name = object_name, 
+            quantization = quantization, ...)
 }
 
 #' @export
@@ -305,11 +317,11 @@ topojson_write.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL,
                                                  group = NULL, file = "myfile.topojson",
                                                  overwrite = TRUE, precision = NULL,
                                                  convert_wgs84 = FALSE, crs = NULL, 
-                                                 object_name = "foo", ...) {
+                                                 object_name = "foo", quantization = 0, ...) {
 
   sp_helper(input, file = file, precision = precision,
             convert_wgs84 = convert_wgs84, crs = crs,
-            class = "SpatialPixelsDataFrame", object_name = object_name, ...)
+            class = "SpatialPixelsDataFrame", object_name = object_name, quantization = quantization, ...)
 }
 
 ## spatial classes from rgeos -----------------
@@ -318,27 +330,27 @@ topojson_write.SpatialRings <- function(input, lat = NULL, lon = NULL, geometry 
                                        group = NULL, file = "myfile.topojson",
                                        overwrite = TRUE, precision = NULL,
                                        convert_wgs84 = FALSE, crs = NULL, 
-                                       object_name = "foo", ...) {
+                                       object_name = "foo", quantization = 0, ...) {
 
   sp_helper(input, file = file, precision = precision,
             convert_wgs84 = convert_wgs84, crs = crs,
-            class = "SpatialRings", object_name = object_name, ...)
+            class = "SpatialRings", object_name = object_name, quantization = quantization, ...)
 }
 
 #' @export
 topojson_write.SpatialRingsDataFrame <- function(input, lat = NULL, lon = NULL,
   geometry = "point", group = NULL, file = "myfile.topojson", overwrite = TRUE,
-  precision = NULL, convert_wgs84 = FALSE, crs = NULL, object_name = "foo", ...) {
+  precision = NULL, convert_wgs84 = FALSE, crs = NULL, object_name = "foo", quantization = 0, ...) {
 
   sp_helper(input, file = file, precision = precision,
             convert_wgs84 = convert_wgs84, crs = crs,
-            class = "SpatialRingsDataFrame", object_name = object_name, ...)
+            class = "SpatialRingsDataFrame", object_name = object_name, quantization = quantization, ...)
 }
 
 #' @export
 topojson_write.SpatialCollections <- function(input, lat = NULL, lon = NULL,
   geometry = "point", group = NULL, file = "myfile.topojson", overwrite = TRUE,
-  precision = NULL, convert_wgs84 = FALSE, crs = NULL, object_name = "foo", ...) {
+  precision = NULL, convert_wgs84 = FALSE, crs = NULL, object_name = "foo", quantization = 0, ...) {
 
   tmp <- suppressMessages(
     geojson_write(input, lat, lon, geometry, group,
@@ -349,7 +361,7 @@ topojson_write.SpatialCollections <- function(input, lat = NULL, lon = NULL,
     if (!is.null(z)) {
       topo_file(
         write_topojson(
-          geo2topo(paste0(readLines(z$path), collapse = ""), object_name),
+          geo2topo(paste0(readLines(z$path), collapse = ""), object_name, quantization),
           sub("\\.geojson|\\.json", "\\.topojson", z$path)
         ),
         z$type
@@ -362,47 +374,47 @@ topojson_write.SpatialCollections <- function(input, lat = NULL, lon = NULL,
 #' @export
 topojson_write.numeric <- function(input, lat = NULL, lon = NULL, geometry = "point",
   group = NULL, file = "myfile.topojson", overwrite = TRUE, precision = NULL, 
-  convert_wgs84 = FALSE, crs = NULL, object_name = "foo", ...) {
+  convert_wgs84 = FALSE, crs = NULL, object_name = "foo", quantization = 0, ...) {
 
   sp_helper(input, lat = lat, lon = lon, geometry = geometry,
             file = file, precision = precision, overwrite = overwrite,
-            class = "numeric", object_name = object_name, ...)
+            class = "numeric", object_name = object_name, quantization = quantization, ...)
 }
 
 #' @export
 topojson_write.data.frame <- function(input, lat = NULL, lon = NULL, geometry = "point",
   group = NULL, file = "myfile.topojson", overwrite = TRUE, precision = NULL, 
-  convert_wgs84 = FALSE, crs = NULL, object_name = "foo", ...) {
+  convert_wgs84 = FALSE, crs = NULL, object_name = "foo", quantization = 0, ...) {
 
   sp_helper(input, lat = lat, lon = lon, geometry = geometry, group = group,
             file = file, precision = precision, overwrite = overwrite,
-            class = "data.frame", object_name = object_name, ...)
+            class = "data.frame", object_name = object_name, quantization = quantization, ...)
 }
 
 #' @export
 topojson_write.list <- function(input, lat = NULL, lon = NULL, geometry="point",
   group = NULL, file = "myfile.topojson", overwrite = TRUE, precision = NULL, 
-  convert_wgs84 = FALSE, crs = NULL, object_name = "foo", ...) {
+  convert_wgs84 = FALSE, crs = NULL, object_name = "foo", quantization = 0, ...) {
 
   sp_helper(input, lat = lat, lon = lon, geometry = geometry, group = group,
             file = file, precision = precision, overwrite = overwrite,
-            class = "list", object_name = object_name, ...)
+            class = "list", object_name = object_name, quantization, ...)
 }
 
 #' @export
 topojson_write.geo_list <- function(input, lat = NULL, lon = NULL, geometry = "point",
   group = NULL, file = "myfile.topojson", overwrite = TRUE, precision = NULL, 
-  convert_wgs84 = FALSE, crs = NULL, object_name = "foo", ...) {
+  convert_wgs84 = FALSE, crs = NULL, object_name = "foo", quantization = 0, ...) {
 
   sp_helper(input, file = file, overwrite = overwrite, class = "geo_list", 
-    object_name = object_name, ...)
+    object_name = object_name, quantization, ...)
 }
 
 # JSON -----------------
 #' @export
 topojson_write.json <- function(input, lat = NULL, lon = NULL, geometry = "point",
   group = NULL, file = "myfile.topojson", overwrite = TRUE, precision = NULL, 
-  convert_wgs84 = FALSE, crs = NULL, object_name = "foo", ...) {
+  convert_wgs84 = FALSE, crs = NULL, object_name = "foo", quantization = 0, ...) {
 
   topo_file(write_topojson(unclass(input), file, ...), "json")
 }
@@ -413,10 +425,10 @@ topojson_write.sf <- function(input, lat = NULL, lon = NULL, geometry = "point",
                              group = NULL, file = "myfile.topojson",
                              overwrite = TRUE, precision = NULL,
                              convert_wgs84 = FALSE, crs = NULL, 
-                             object_name = "foo", ...) {
+                             object_name = "foo", quantization = 0, ...) {
 
   topo_write_sf(input, convert_wgs84, crs, file, overwrite, "sf", 
-    object_name, ...)
+    object_name, quantization, ...)
 }
 
 #' @export
@@ -424,10 +436,10 @@ topojson_write.sfc <- function(input, lat = NULL, lon = NULL, geometry = "point"
                               group = NULL, file = "myfile.topojson",
                               overwrite = TRUE, precision = NULL,
                               convert_wgs84 = FALSE, crs = NULL,
-                              object_name = "foo", ...) {
+                              object_name = "foo", quantization = 0, ...) {
 
   topo_write_sf(input, convert_wgs84, crs, file, overwrite, "sfc", 
-    object_name, ...)
+    object_name, quantization, ...)
 }
 
 #' @export
@@ -435,14 +447,14 @@ topojson_write.sfg <- function(input, lat = NULL, lon = NULL, geometry = "point"
                               group = NULL, file = "myfile.topojson",
                               overwrite = TRUE, precision = NULL,
                               convert_wgs84 = FALSE, crs = NULL,
-                              object_name = "foo", ...) {
+                              object_name = "foo", quantization = 0, ...) {
 
   topo_write_sf(input, convert_wgs84, crs, file, overwrite, "sfg", 
-    object_name, ...)
+    object_name, quantization, ...)
 }
 
 topo_write_sf <- function(input, convert_wgs84, crs, file, overwrite, 
-  class, object_name, ...) {
+  class, object_name, quantization, ...) {
 
   tmp <- suppressMessages(
     geojson_write(input, convert_wgs84 = convert_wgs84,
@@ -452,7 +464,7 @@ topo_write_sf <- function(input, convert_wgs84, crs, file, overwrite,
   topo_file(
     write_topojson(
       geo2topo(paste0(readLines(tmp$path, warn = FALSE), collapse = ""), 
-        object_name), file),
+        object_name, quantization), file),
     "sfc"
   )
 }
@@ -474,7 +486,7 @@ sp_helper <- function(input, lat = NULL, lon = NULL, geometry = "point",
                       group = NULL, file = "myfile.topojson",
                       overwrite = TRUE, precision = NULL,
                       convert_wgs84 = FALSE, crs = NULL, 
-                      class, object_name, ...) {
+                      class, object_name, quantization, ...) {
 
   res <- suppressMessages(
     geojson_write(
@@ -487,7 +499,7 @@ sp_helper <- function(input, lat = NULL, lon = NULL, geometry = "point",
     write_topojson(
       geo2topo(
         paste0(readLines(res$path, warn = FALSE), collapse = ""), 
-        object_name
+        object_name, quantization
       ), 
       file
     ),

--- a/man/geo2topo.Rd
+++ b/man/geo2topo.Rd
@@ -5,7 +5,7 @@
 \alias{topo2geo}
 \title{GeoJSON to TopoJSON and back}
 \usage{
-geo2topo(x, object_name = "foo", ...)
+geo2topo(x, object_name = "foo", quantization = 0, ...)
 
 topo2geo(x, ...)
 }
@@ -15,6 +15,10 @@ url}
 
 \item{object_name}{(character) name to give to the TopoJSON object created. 
 Default: "foo"}
+
+\item{quantization}{(numeric) quantization parameter, use this to
+quantize geometry prior to computing topology. Typical values are powers of 
+ten (\code{1e4}, \code{1e5}, ...), default is \code{0} to not perform quantization.}
 
 \item{...}{for \code{geo2topo} args passed  on to
 \code{\link[jsonlite]{fromJSON}}, and for \code{topo2geo} args passed  on to

--- a/man/geo2topo.Rd
+++ b/man/geo2topo.Rd
@@ -18,7 +18,10 @@ Default: "foo"}
 
 \item{quantization}{(numeric) quantization parameter, use this to
 quantize geometry prior to computing topology. Typical values are powers of 
-ten (\code{1e4}, \code{1e5}, ...), default is \code{0} to not perform quantization.}
+ten (\code{1e4}, \code{1e5}, ...), default is \code{0} to not perform quantization.
+For more information about quantization, see this 
+\href{https://stackoverflow.com/questions/18900022/topojson-quantization-vs-simplification/18921214#18921214}{
+StackOverflow post by Mike Bostock}.}
 
 \item{...}{for \code{geo2topo} args passed  on to
 \code{\link[jsonlite]{fromJSON}}, and for \code{topo2geo} args passed  on to

--- a/man/topojson_write.Rd
+++ b/man/topojson_write.Rd
@@ -7,7 +7,7 @@
 topojson_write(input, lat = NULL, lon = NULL, geometry = "point",
   group = NULL, file = "myfile.topojson", overwrite = TRUE,
   precision = NULL, convert_wgs84 = FALSE, crs = NULL,
-  object_name = "foo", ...)
+  object_name = "foo", quantization = 0, ...)
 }
 \arguments{
 \item{input}{Input list, data.frame, spatial class, or sf class. Inputs can 
@@ -52,6 +52,10 @@ object already has a CRS.}
 
 \item{object_name}{(character) name to give to the TopoJSON object created.
 Default: "foo"}
+
+\item{quantization}{(numeric) quantization parameter, use this to
+quantize geometry prior to computing topology. Typical values are powers of 
+ten (\code{1e4}, \code{1e5}, ...), default is \code{0} to not perform quantization.}
 
 \item{...}{Further args passed on to internal functions. For Spatial* 
 classes, data.frames,

--- a/man/topojson_write.Rd
+++ b/man/topojson_write.Rd
@@ -55,7 +55,10 @@ Default: "foo"}
 
 \item{quantization}{(numeric) quantization parameter, use this to
 quantize geometry prior to computing topology. Typical values are powers of 
-ten (\code{1e4}, \code{1e5}, ...), default is \code{0} to not perform quantization.}
+ten (\code{1e4}, \code{1e5}, ...), default is \code{0} to not perform quantization.
+For more information about quantization, see this 
+\href{https://stackoverflow.com/questions/18900022/topojson-quantization-vs-simplification/18921214#18921214}{
+StackOverflow post by Mike Bostock}.}
 
 \item{...}{Further args passed on to internal functions. For Spatial* 
 classes, data.frames,

--- a/tests/testthat/test-geo_topo.R
+++ b/tests/testthat/test-geo_topo.R
@@ -23,6 +23,10 @@ test_that("setting the object_name in geo2topo works", {
   x <- '{"type": "LineString", "coordinates": [ [100.0, 0.0], [101.0, 1.0] ]}'
   z <- geo2topo(x, object_name = "HelloWorld")
   expect_true(grepl("HelloWorld", z))
+  # quantization=0 : no transform/scale/translate attribute
+  expect_false(grepl("transform", z))
+  expect_false(grepl("scale", z))
+  expect_false(grepl("translate", z))
   
   y <- list(
     '{"type": "LineString", "coordinates": [ [100, 0], [101, 1] ]}',
@@ -33,6 +37,10 @@ test_that("setting the object_name in geo2topo works", {
   a <- geo2topo(y, nms)
   lapply(seq_along(a), function(x) {
     expect_true(grepl(nms[x], a[[x]]))
+    # quantization=0 : no transform/scale/translate attribute
+    expect_false(grepl("transform", a[[x]]))
+    expect_false(grepl("scale", a[[x]]))
+    expect_false(grepl("translate", a[[x]]))
   })
 })
 
@@ -45,30 +53,8 @@ test_that("topo2geo works", {
 
 
 
-test_that("quantization=0 in geo2topo", {
-  x <- '{"type": "LineString", "coordinates": [ [100.0, 0.0], [101.0, 1.0] ]}'
-  z <- geo2topo(x, object_name = "HelloWorld", quantization = 0)
-  # no transform attribute
-  expect_false(grepl("transform", z))
-  expect_false(grepl("scale", z))
-  expect_false(grepl("translate", z))
-  
-  y <- list(
-    '{"type": "LineString", "coordinates": [ [100, 0], [101, 1] ]}',
-    '{"type": "LineString", "coordinates": [ [110, 0], [110, 1] ]}',
-    '{"type": "LineString", "coordinates": [ [120, 0], [121, 1] ]}'
-  )
-  a <- geo2topo(y)
-  
-  lapply(seq_along(a), function(x) {
-    expect_false(grepl("transform", a[[x]]))
-    expect_false(grepl("scale", a[[x]]))
-    expect_false(grepl("translate", a[[x]]))
-  })
-})
 
-
-test_that("quantization>0 in geo2topo", {
+test_that("quantization > 0 in geo2topo", {
   x <- '{"type": "LineString", "coordinates": [ [100.0, 0.0], [101.0, 1.0] ]}'
   z <- geo2topo(x, object_name = "HelloWorld", quantization = 1e4)
   # no transform attribute

--- a/tests/testthat/test-geo_topo.R
+++ b/tests/testthat/test-geo_topo.R
@@ -42,3 +42,53 @@ test_that("topo2geo works", {
   expect_s3_class(w, "geofeaturecollection")
 })
 
+
+
+
+test_that("quantization=0 in geo2topo", {
+  x <- '{"type": "LineString", "coordinates": [ [100.0, 0.0], [101.0, 1.0] ]}'
+  z <- geo2topo(x, object_name = "HelloWorld", quantization = 0)
+  # no transform attribute
+  expect_false(grepl("transform", z))
+  expect_false(grepl("scale", z))
+  expect_false(grepl("translate", z))
+  
+  y <- list(
+    '{"type": "LineString", "coordinates": [ [100, 0], [101, 1] ]}',
+    '{"type": "LineString", "coordinates": [ [110, 0], [110, 1] ]}',
+    '{"type": "LineString", "coordinates": [ [120, 0], [121, 1] ]}'
+  )
+  a <- geo2topo(y)
+  
+  lapply(seq_along(a), function(x) {
+    expect_false(grepl("transform", a[[x]]))
+    expect_false(grepl("scale", a[[x]]))
+    expect_false(grepl("translate", a[[x]]))
+  })
+})
+
+
+test_that("quantization>0 in geo2topo", {
+  x <- '{"type": "LineString", "coordinates": [ [100.0, 0.0], [101.0, 1.0] ]}'
+  z <- geo2topo(x, object_name = "HelloWorld", quantization = 1e4)
+  # no transform attribute
+  expect_true(grepl("transform", z))
+  expect_true(grepl("scale", z))
+  expect_true(grepl("translate", z))
+  
+  y <- list(
+    '{"type": "LineString", "coordinates": [ [100, 0], [101, 1] ]}',
+    '{"type": "LineString", "coordinates": [ [110, 0], [110, 1] ]}',
+    '{"type": "LineString", "coordinates": [ [120, 0], [121, 1] ]}'
+  )
+  a <- geo2topo(y, quantization = 1e4)
+  
+  lapply(seq_along(a), function(x) {
+    expect_true(grepl("transform", a[[x]]))
+    expect_true(grepl("scale", a[[x]]))
+    expect_true(grepl("translate", a[[x]]))
+  })
+})
+
+
+

--- a/tests/testthat/test-topojson_write.R
+++ b/tests/testthat/test-topojson_write.R
@@ -105,11 +105,14 @@ test_that("topojson_write works with different object name", {
   x <- topojson_write(vec, file = gwf9, object_name = "California")
   expect_s3_class(x, "topojson_file")
   expect_true(grepl("California", readLines(gwf9)))
-  
+  # quantization=0 : no transform/scale/translate attribute
+  expect_false(grepl("transform", readLines(gwf9)))
+  expect_false(grepl("scale", readLines(gwf9)))
+  expect_false(grepl("translate", readLines(gwf9)))
 })
 
 
-test_that("topojson_write works with quantization >0", {
+test_that("topojson_write works with quantization > 0", {
   vec <- c(-99.74, 32.45)
   gwf9 <- tempfile(fileext = ".topojson")
   x <- topojson_write(vec, file = gwf9, quantization = 1e4)
@@ -119,12 +122,3 @@ test_that("topojson_write works with quantization >0", {
   expect_true(grepl("translate", readLines(gwf9)))
 })
 
-test_that("topojson_write works with quantization =0", {
-  vec <- c(-99.74, 32.45)
-  gwf9 <- tempfile(fileext = ".topojson")
-  x <- topojson_write(vec, file = gwf9, quantization = 0)
-  expect_s3_class(x, "topojson_file")
-  expect_false(grepl("transform", readLines(gwf9)))
-  expect_false(grepl("scale", readLines(gwf9)))
-  expect_false(grepl("translate", readLines(gwf9)))
-})

--- a/tests/testthat/test-topojson_write.R
+++ b/tests/testthat/test-topojson_write.R
@@ -108,3 +108,23 @@ test_that("topojson_write works with different object name", {
   
 })
 
+
+test_that("topojson_write works with quantization >0", {
+  vec <- c(-99.74, 32.45)
+  gwf9 <- tempfile(fileext = ".topojson")
+  x <- topojson_write(vec, file = gwf9, quantization = 1e4)
+  expect_s3_class(x, "topojson_file")
+  expect_true(grepl("transform", readLines(gwf9)))
+  expect_true(grepl("scale", readLines(gwf9)))
+  expect_true(grepl("translate", readLines(gwf9)))
+})
+
+test_that("topojson_write works with quantization =0", {
+  vec <- c(-99.74, 32.45)
+  gwf9 <- tempfile(fileext = ".topojson")
+  x <- topojson_write(vec, file = gwf9, quantization = 0)
+  expect_s3_class(x, "topojson_file")
+  expect_false(grepl("transform", readLines(gwf9)))
+  expect_false(grepl("scale", readLines(gwf9)))
+  expect_false(grepl("translate", readLines(gwf9)))
+})


### PR DESCRIPTION
Added quantization parameter in `geo2topo`

## Description
`topojson.topology` allow a second parameter to perform quantization on geometries before computing topologies. I added an argument to `geo2topo` and `topojson_write` (and associated methods) to be able to use this parameter in the JS call.


## Example
Quantization allow to create the `transform` attribute in ouput topojson with two arrays: `scale` and `transform` : 

```r
x <- '{"type": "LineString", "coordinates": [ [100.0, 0.0], [101.0, 1.0] ]}'
jsonlite::prettify(geo2topo(x, object_name = "HelloWorld"))
# {
#   "type": "Topology",
#   "objects": {
#     "HelloWorld": {
#       "type": "LineString",
#       "arcs": [0]
#     }
#   },
#   "arcs": [[[100, 0], [101, 1]]],
#   "bbox": [100, 0, 101, 1]
# }
jsonlite::prettify(geo2topo(x, object_name = "HelloWorld", quantization = 1e4))
# {
#   "type": "Topology",
#   "objects": {
#     "HelloWorld": {
#       "type": "LineString",
#       "arcs": [0]
#     }
#   },
#   "arcs": [[0, 0], [9999, 9999]]],
#   "bbox": [100, 0, 101, 1],
#   "transform": {
#     "scale": [0.00010001000100010001, 0.00010001000100010001],
#     "translate": [100, 0]
#   }
# }
```

Thanks for your work, it's really a good package.

Victor
