### PR TITLE
removed `and mac` from sentence about CRAN

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -72,7 +72,7 @@ Additional functions:
 
 ## Install
 
-A note about installing `rgdal` and `rgeos` - these two packages are built on top of C libraries, and their installation often causes trouble for Mac and Linux users because no binaries are provided on CRAN for those platforms. Other dependencies in `geojsonio` should install easily automatically when you install `geojsonio`. Change to the version of `rgdal` and `GDAL` you have):
+A note about installing `rgdal` and `rgeos` - these two packages are built on top of C libraries, and their installation often causes trouble for Linux users because no binaries are provided on CRAN for those platforms. Other dependencies in `geojsonio` should install easily automatically when you install `geojsonio`. Change to the version of `rgdal` and `GDAL` you have):
 
 _Mac_
 


### PR DESCRIPTION
## Description
Hi there, love the package! I think that the readme can just say that installing the dependencies is hard on Linux rather than Linux and mac, because on mac, as far as I know, `rgdal` and `rgeos` have compiled binaries.

On my mac, I just ran `time Rscript -e "remove.packages(c('rgdal', 'rgeos', 'geojsonio'))"` and it took `0m6.339s` with zero compilation. (I had removed all three packages from my computer first just to be sure.)
