### PR TITLE
Add precision variable to geojson_list()

### DIFF
--- a/R/geojson_list.R
+++ b/R/geojson_list.R
@@ -13,7 +13,8 @@
 #' for points
 #' @param precision desired number of decimal places for the coordinates in the
 #'   geojson file. Using fewer decimal places can decrease file sizes (at the
-#'   cost of precision).
+#'   cost of precision). This changes the underlying precision stored in the data.
+#'   If you want to change the number of digits displayed use options(digits = <some number>).
 #' @param convert_wgs84 Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate reference system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude units of decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.
 #' @param crs The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_wgs84} is \code{FALSE} or the object already has a CRS.
 #' @param ... Ignored
@@ -84,7 +85,20 @@
 #'    c(30,40,35,30)))), "2")
 #' sp_poly <- SpatialPolygons(list(poly1, poly2), 1:2)
 #' geojson_list(sp_poly)
+#' 
+#' # From SpatialPolygons class with precision agreement
+#' x_coord <- c(-114.345703125, -114.345703125, -106.61132812499999, -106.61132812499999,-114.345703125)
+#' y_coord <- c(39.436192999314095, 43.45291889355468, 43.45291889355468, 39.436192999314095, 39.436192999314095)
+#' coords <- cbind(x_coord, y_coord)
+#' poly <- Polygon(coords)
+#' polys <- Polygons(list(poly), 1)
+#' sp_poly2 <- SpatialPolygons(list(polys))
+#' geojson_list(sp_poly2, geometry = "polygon", precision = 4)
 #'
+#' # From SpatialPoints class with precision
+#' points <- SpatialPoints(cbind(x_coord,y_coord))
+#' geojson_list(points)
+#' 
 #' # From SpatialPolygonsDataFrame class
 #' sp_polydf <- as(sp_poly, "SpatialPolygonsDataFrame")
 #' geojson_list(input = sp_polydf)
@@ -94,7 +108,7 @@
 #' y <- c(3,2,5,1,4)
 #' s <- SpatialPoints(cbind(x,y))
 #' geojson_list(s)
-#'
+#' 
 #' # From SpatialPointsDataFrame class
 #' s <- SpatialPointsDataFrame(cbind(x,y), mtcars[1:5,])
 #' geojson_list(s)

--- a/R/geojson_list.R
+++ b/R/geojson_list.R
@@ -195,7 +195,7 @@
 
 geojson_list <- function(input, lat = NULL, lon = NULL, group = NULL,
                          geometry = "point", type = "FeatureCollection",
-                         convert_wgs84 = FALSE, crs = NULL, ...) {
+                         precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
   UseMethod("geojson_list")
 }
 
@@ -203,8 +203,8 @@ geojson_list <- function(input, lat = NULL, lon = NULL, group = NULL,
 #' @export
 geojson_list.SpatialPolygons <- function(input, lat = NULL, lon = NULL, group = NULL,
                                          geometry = "point", type = "FeatureCollection",
-                                         convert_wgs84 = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
+                                         precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialPolygons")
 }
 
@@ -212,33 +212,33 @@ geojson_list.SpatialPolygons <- function(input, lat = NULL, lon = NULL, group = 
 geojson_list.SpatialPolygonsDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                   group = NULL, geometry = "point", 
                                                   type = "FeatureCollection",
-                                                  convert_wgs84 = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
+                                                  precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialPolygonsDataFrame")
 }
 
 #' @export
 geojson_list.SpatialPoints <- function(input, lat = NULL, lon = NULL, group = NULL,
                                        geometry = "point", type = "FeatureCollection",
-                                       convert_wgs84 = FALSE, crs = NULL, ...) {
+                                       precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
   dat <- SpatialPointsDataFrame(input, data.frame(dat = 1:NROW(input@coords)))
-  as.geo_list(geojson_rw(dat, target = "list", convert_wgs84 = convert_wgs84, crs = crs), "SpatialPoints")
+  as.geo_list(geojson_rw(dat, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs), "SpatialPoints")
 }
 
 #' @export
 geojson_list.SpatialPointsDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                 group = NULL, geometry = "point", 
                                                 type = "FeatureCollection",
-                                                convert_wgs84 = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
+                                                precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialPointsDataFrame")
 }
 
 #' @export
 geojson_list.SpatialLines <- function(input, lat = NULL, lon = NULL, group = NULL,
                                       geometry = "point", type = "FeatureCollection",
-                                      convert_wgs84 = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
+                                      precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialLines")
 }
 
@@ -246,16 +246,16 @@ geojson_list.SpatialLines <- function(input, lat = NULL, lon = NULL, group = NUL
 geojson_list.SpatialLinesDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                group = NULL, geometry = "point", 
                                                type = "FeatureCollection",
-                                               convert_wgs84 = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
+                                               precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialLinesDataFrame")
 }
 
 #' @export
 geojson_list.SpatialGrid <- function(input, lat = NULL, lon = NULL, group = NULL,
                                      geometry = "point", type = "FeatureCollection",
-                                     convert_wgs84 = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
+                                     precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialGrid")
 }
 
@@ -263,16 +263,16 @@ geojson_list.SpatialGrid <- function(input, lat = NULL, lon = NULL, group = NULL
 geojson_list.SpatialGridDataFrame <- function(input, lat = NULL, lon = NULL, 
                                               group = NULL, geometry = "point", 
                                               type = "FeatureCollection",
-                                              convert_wgs84 = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
+                                              precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialGridDataFrame")
 }
 
 #' @export
 geojson_list.SpatialPixels <- function(input, lat = NULL, lon = NULL, group = NULL,
                                        geometry = "point",  type='FeatureCollection',
-                                       convert_wgs84 = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
+                                       precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialPixels")
 }
 
@@ -280,8 +280,8 @@ geojson_list.SpatialPixels <- function(input, lat = NULL, lon = NULL, group = NU
 geojson_list.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                 group = NULL, geometry = "point", 
                                                 type = "FeatureCollection",
-                                                convert_wgs84 = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
+                                                precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialPixelsDataFrame")
 }
 
@@ -289,8 +289,8 @@ geojson_list.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL,
 #' @export
 geojson_list.SpatialRings <- function(input, lat = NULL, lon = NULL, group = NULL,
                                       geometry = "point",  type='FeatureCollection',
-                                      convert_wgs84 = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
+                                      precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialRings")
 }
 
@@ -298,8 +298,8 @@ geojson_list.SpatialRings <- function(input, lat = NULL, lon = NULL, group = NUL
 geojson_list.SpatialRingsDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                group = NULL, geometry = "point", 
                                                type = "FeatureCollection",
-                                               convert_wgs84 = FALSE, crs = NULL, ...) {
-  as.geo_list(geojson_rw(input, target = "list", convert_wgs84 = convert_wgs84, crs = crs),
+                                               precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+  as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialRingsDataFrame")
 }
 
@@ -307,7 +307,7 @@ geojson_list.SpatialRingsDataFrame <- function(input, lat = NULL, lon = NULL,
 geojson_list.SpatialCollections <- function(input, lat = NULL, lon = NULL, 
                                             group = NULL, geometry = "point", 
                                             type = "FeatureCollection",
-                                            convert_wgs84 = FALSE, crs = NULL, ...) {
+                                            precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
   pt <- donotnull(input@pointobj, geojson_rw, target = "list", 
                   convert_wgs84 = convert_wgs84, crs = crs)
   ln <- donotnull(input@lineobj, geojson_rw, target = "list", 

--- a/R/geojson_list.R
+++ b/R/geojson_list.R
@@ -11,6 +11,9 @@
 #' GeometryCollection.
 #' @param group (character) A grouping variable to perform grouping for polygons - doesn't apply
 #' for points
+#' @param precision desired number of decimal places for the coordinates in the
+#'   geojson file. Using fewer decimal places can decrease file sizes (at the
+#'   cost of precision).
 #' @param convert_wgs84 Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate reference system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude units of decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.
 #' @param crs The CRS of the input if it is not already defined. This can be an epsg code as a four or five digit integer or a valid proj4 string. This argument will be ignored if \code{convert_wgs84} is \code{FALSE} or the object already has a CRS.
 #' @param ... Ignored

--- a/R/geojson_list.R
+++ b/R/geojson_list.R
@@ -198,7 +198,7 @@
 
 geojson_list <- function(input, lat = NULL, lon = NULL, group = NULL,
                          geometry = "point", type = "FeatureCollection",
-                         precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+                         convert_wgs84 = FALSE, crs = NULL, precision = NULL, ...) {
   UseMethod("geojson_list")
 }
 
@@ -206,7 +206,7 @@ geojson_list <- function(input, lat = NULL, lon = NULL, group = NULL,
 #' @export
 geojson_list.SpatialPolygons <- function(input, lat = NULL, lon = NULL, group = NULL,
                                          geometry = "point", type = "FeatureCollection",
-                                         precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+                                         convert_wgs84 = FALSE, crs = NULL, precision = NULL,  ...) {
   as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialPolygons")
 }
@@ -215,7 +215,7 @@ geojson_list.SpatialPolygons <- function(input, lat = NULL, lon = NULL, group = 
 geojson_list.SpatialPolygonsDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                   group = NULL, geometry = "point", 
                                                   type = "FeatureCollection",
-                                                  precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+                                                  convert_wgs84 = FALSE, crs = NULL, precision = NULL,  ...) {
   as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialPolygonsDataFrame")
 }
@@ -223,7 +223,7 @@ geojson_list.SpatialPolygonsDataFrame <- function(input, lat = NULL, lon = NULL,
 #' @export
 geojson_list.SpatialPoints <- function(input, lat = NULL, lon = NULL, group = NULL,
                                        geometry = "point", type = "FeatureCollection",
-                                       precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+                                       convert_wgs84 = FALSE, crs = NULL, precision = NULL,  ...) {
   dat <- SpatialPointsDataFrame(input, data.frame(dat = 1:NROW(input@coords)))
   as.geo_list(geojson_rw(dat, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs), "SpatialPoints")
 }
@@ -232,7 +232,7 @@ geojson_list.SpatialPoints <- function(input, lat = NULL, lon = NULL, group = NU
 geojson_list.SpatialPointsDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                 group = NULL, geometry = "point", 
                                                 type = "FeatureCollection",
-                                                precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+                                                convert_wgs84 = FALSE, crs = NULL, precision = NULL,  ...) {
   as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialPointsDataFrame")
 }
@@ -240,7 +240,7 @@ geojson_list.SpatialPointsDataFrame <- function(input, lat = NULL, lon = NULL,
 #' @export
 geojson_list.SpatialLines <- function(input, lat = NULL, lon = NULL, group = NULL,
                                       geometry = "point", type = "FeatureCollection",
-                                      precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+                                      convert_wgs84 = FALSE, crs = NULL, precision = NULL,  ...) {
   as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialLines")
 }
@@ -249,7 +249,7 @@ geojson_list.SpatialLines <- function(input, lat = NULL, lon = NULL, group = NUL
 geojson_list.SpatialLinesDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                group = NULL, geometry = "point", 
                                                type = "FeatureCollection",
-                                               precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+                                               convert_wgs84 = FALSE, crs = NULL, precision = NULL,  ...) {
   as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialLinesDataFrame")
 }
@@ -257,7 +257,7 @@ geojson_list.SpatialLinesDataFrame <- function(input, lat = NULL, lon = NULL,
 #' @export
 geojson_list.SpatialGrid <- function(input, lat = NULL, lon = NULL, group = NULL,
                                      geometry = "point", type = "FeatureCollection",
-                                     precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+                                     convert_wgs84 = FALSE, crs = NULL, precision = NULL,  ...) {
   as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialGrid")
 }
@@ -266,7 +266,7 @@ geojson_list.SpatialGrid <- function(input, lat = NULL, lon = NULL, group = NULL
 geojson_list.SpatialGridDataFrame <- function(input, lat = NULL, lon = NULL, 
                                               group = NULL, geometry = "point", 
                                               type = "FeatureCollection",
-                                              precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+                                              convert_wgs84 = FALSE, crs = NULL, precision = NULL,  ...) {
   as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialGridDataFrame")
 }
@@ -274,7 +274,7 @@ geojson_list.SpatialGridDataFrame <- function(input, lat = NULL, lon = NULL,
 #' @export
 geojson_list.SpatialPixels <- function(input, lat = NULL, lon = NULL, group = NULL,
                                        geometry = "point",  type='FeatureCollection',
-                                       precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+                                       convert_wgs84 = FALSE, crs = NULL, precision = NULL,  ...) {
   as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialPixels")
 }
@@ -283,7 +283,7 @@ geojson_list.SpatialPixels <- function(input, lat = NULL, lon = NULL, group = NU
 geojson_list.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                 group = NULL, geometry = "point", 
                                                 type = "FeatureCollection",
-                                                precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+                                                convert_wgs84 = FALSE, crs = NULL, precision = NULL,  ...) {
   as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialPixelsDataFrame")
 }
@@ -292,7 +292,7 @@ geojson_list.SpatialPixelsDataFrame <- function(input, lat = NULL, lon = NULL,
 #' @export
 geojson_list.SpatialRings <- function(input, lat = NULL, lon = NULL, group = NULL,
                                       geometry = "point",  type='FeatureCollection',
-                                      precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+                                      convert_wgs84 = FALSE, crs = NULL, precision = NULL,  ...) {
   as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialRings")
 }
@@ -301,7 +301,7 @@ geojson_list.SpatialRings <- function(input, lat = NULL, lon = NULL, group = NUL
 geojson_list.SpatialRingsDataFrame <- function(input, lat = NULL, lon = NULL, 
                                                group = NULL, geometry = "point", 
                                                type = "FeatureCollection",
-                                               precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+                                               convert_wgs84 = FALSE, crs = NULL, precision = NULL,  ...) {
   as.geo_list(geojson_rw(input, target = "list", precision = precision, convert_wgs84 = convert_wgs84, crs = crs),
               "SpatialRingsDataFrame")
 }
@@ -310,7 +310,7 @@ geojson_list.SpatialRingsDataFrame <- function(input, lat = NULL, lon = NULL,
 geojson_list.SpatialCollections <- function(input, lat = NULL, lon = NULL, 
                                             group = NULL, geometry = "point", 
                                             type = "FeatureCollection",
-                                            precision = NULL, convert_wgs84 = FALSE, crs = NULL, ...) {
+                                            convert_wgs84 = FALSE, crs = NULL, precision = NULL,  ...) {
   pt <- donotnull(input@pointobj, geojson_rw, target = "list", 
                   convert_wgs84 = convert_wgs84, crs = crs)
   ln <- donotnull(input@lineobj, geojson_rw, target = "list", 

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -334,8 +334,8 @@ convert_unsupported_classes <- function(df) {
 }
 
 geojson_rw <- function(input, target = c("char", "list"),
-                       precision = NULL, convert_wgs84 = FALSE, 
-                       crs = NULL, ...){
+                       convert_wgs84 = FALSE, crs = NULL, 
+                       precision = NULL, ...){
 
   read_fun <- switch(target,
                      char = geojson_file_to_char,

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -334,7 +334,8 @@ convert_unsupported_classes <- function(df) {
 }
 
 geojson_rw <- function(input, target = c("char", "list"),
-                       convert_wgs84 = FALSE, crs = NULL, ...){
+                       precision = NULL, convert_wgs84 = FALSE, 
+                       crs = NULL, ...){
 
   read_fun <- switch(target,
                      char = geojson_file_to_char,
@@ -343,14 +344,14 @@ geojson_rw <- function(input, target = c("char", "list"),
   if (inherits(input, "SpatialCollections")) {
     tmp <- tempfile(fileext = ".geojson")
     on.exit(unlink(tmp))
-    tmp2 <- suppressMessages(geojson_write(input, file = tmp,
+    tmp2 <- suppressMessages(geojson_write(input, file = tmp, precision = precision,
                                            convert_wgs84 = convert_wgs84, crs = crs))
     paths <- vapply(tg_compact(tmp2), "[[", "", "path")
     lapply(paths, read_fun, ...)
   } else {
     tmp <- tempfile(fileext = ".geojson")
     on.exit(unlink(tmp))
-    suppressMessages(geojson_write(input, file = tmp,
+    suppressMessages(geojson_write(input, file = tmp, precision = precision,
                                    convert_wgs84 = convert_wgs84, crs = crs))
     read_fun(tmp, ...)
   }

--- a/man/geojson_list.Rd
+++ b/man/geojson_list.Rd
@@ -5,7 +5,7 @@
 \title{Convert many input types with spatial data to geojson specified as a list}
 \usage{
 geojson_list(input, lat = NULL, lon = NULL, group = NULL,
-  geometry = "point", type = "FeatureCollection",
+  geometry = "point", type = "FeatureCollection", precision = NULL,
   convert_wgs84 = FALSE, crs = NULL, ...)
 }
 \arguments{
@@ -23,6 +23,10 @@ for points}
 
 \item{type}{(character) The type of collection. One of FeatureCollection (default) or
 GeometryCollection.}
+
+\item{precision}{desired number of decimal places for the coordinates in the
+geojson file. Using fewer decimal places can decrease file sizes (at the
+cost of precision).}
 
 \item{convert_wgs84}{Should the input be converted to the \href{https://tools.ietf.org/html/rfc7946}{standard coordinate reference system defined for GeoJSON} (geographic coordinate reference system, using the WGS84 datum, with longitude and latitude units of decimal degrees; EPSG: 4326). Default is \code{FALSE} though this may change in a future package version. This will only work for \code{sf} or \code{Spatial} objects with a CRS already defined. If one is not defined but you know what it is, you may define it in the \code{crs} argument below.}
 

--- a/tests/testthat/test-geojson_list.R
+++ b/tests/testthat/test-geojson_list.R
@@ -44,7 +44,7 @@ test_that("geojson_list works with numeric inputs", {
   )
 })
 
-test_that("geojson precision arguement works with sp classes") {
+test_that("geojson precision arguement works with sp classes", {
   ## polygon type
   x_coord <- c(-114.345703125, -114.345703125, -106.61132812499999, -106.61132812499999,-114.345703125)
   y_coord <- c(39.436192999314095, 43.45291889355468, 43.45291889355468, 39.436192999314095, 39.436192999314095)
@@ -63,7 +63,7 @@ test_that("geojson precision arguement works with sp classes") {
         "coordinates"))), .Names = c("type", "id", "properties", "geometry"
     )))), .Names = c("type", "features"), from = "SpatialPolygons")
   )
-}
+})
 
 test_that("geojson_list works with data.frame inputs", {
   # From a data.frame to points

--- a/tests/testthat/test-geojson_list.R
+++ b/tests/testthat/test-geojson_list.R
@@ -44,6 +44,27 @@ test_that("geojson_list works with numeric inputs", {
   )
 })
 
+test_that("geojson precision arguement works with sp classes") {
+  ## polygon type
+  x_coord <- c(-114.345703125, -114.345703125, -106.61132812499999, -106.61132812499999,-114.345703125)
+  y_coord <- c(39.436192999314095, 43.45291889355468, 43.45291889355468, 39.436192999314095, 39.436192999314095)
+  coords <- cbind(x_coord, y_coord)
+  poly <- Polygon(coords)
+  polys <- Polygons(list(poly), 1)
+  sp_poly <- SpatialPolygons(list(polys))
+  expect_equal(
+    unclass(geojson_list(sp_poly, geometry = "polygon", precision = 4)),
+    structure(list(type = "FeatureCollection", features = list(structure(list(
+        type = "Feature", id = as.integer(1), properties = structure(list(dummy = 0)), geometry = structure(list(type = "Polygon",
+            coordinates = list(list(c(-114.3457, 39.4362
+            ), c(-114.3457, 43.4529), c(-106.6113,
+            43.4529), c(-106.6113, 39.4362
+            ), c(-114.3457, 39.4362)))), .Names = c("type",
+        "coordinates"))), .Names = c("type", "id", "properties", "geometry"
+    )))), .Names = c("type", "features"), from = "SpatialPolygons")
+  )
+}
+
 test_that("geojson_list works with data.frame inputs", {
   # From a data.frame to points
   expect_equal(


### PR DESCRIPTION
## Description
Added precision argument to geojson_rw() with default to NULL to avoid changing behavior when the argument isn't used.  Then used this change to add precision to geojson_list() specifically for all sp class calls. I haven't tested this for non-sp classes yet.

## Related Issue
related to #141 for the case when converting from sp classes to geoJSON.  

## Example
```R
  x_coord <- c(-114.345703125, -114.345703125, -106.61132812499999, -106.61132812499999,-114.345703125)
  y_coord <- c(39.436192999314095, 43.45291889355468, 43.45291889355468, 39.436192999314095, 39.436192999314095)
  coords <- cbind(x_coord, y_coord)
  poly <- Polygon(coords)
  polys <- Polygons(list(poly), 1)
  sp_poly <- SpatialPolygons(list(polys))
  geojson_list(sp_poly, geometry = "polygon", precision = 4)
```

test added for precision for sp polygons works with other sp classes