### PR TITLE
Add GitHub Actions CI to test various platforms

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -22,4 +22,3 @@ man-roxygen
 ^codemeta\.json$
 .txt
 inst/ignore/Dockerfile
-^\.github/workflows/R-CMD-check\.yaml$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -22,3 +22,4 @@ man-roxygen
 ^codemeta\.json$
 .txt
 inst/ignore/Dockerfile
+^\.github/workflows/R-CMD-check\.yaml$

--- a/.github/workflows/R-CMD-check-docker.yaml
+++ b/.github/workflows/R-CMD-check-docker.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: Rscript -e "install.packages('remotes')" -e "remotes::install_deps(dependencies = TRUE)" -e "remotes::install_cran('rcmdcheck')"
 
-      - name: Check${{ 
+      - name: Check
         run: Rscript -e "rcmdcheck::rcmdcheck(args = '--as-cran --no-manual', error_on = 'warning', check_dir = 'check')"
 
       - name: Upload check results

--- a/.github/workflows/R-CMD-check-docker.yaml
+++ b/.github/workflows/R-CMD-check-docker.yaml
@@ -13,14 +13,6 @@ jobs:
 
       - uses: r-lib/actions/setup-tinytex@master
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get install -y software-properties-common
-          sudo apt-get -y update
-          sudo add-apt-repository -y ppa:cran/v8
-          sudo apt-get -y update
-          sudo apt-get install -y libnode-dev
-
       - name: Install dependencies
         run: Rscript -e "install.packages('remotes')" -e "remotes::install_deps(dependencies = TRUE)" -e "remotes::install_cran('rcmdcheck')"
 

--- a/.github/workflows/R-CMD-check-docker.yaml
+++ b/.github/workflows/R-CMD-check-docker.yaml
@@ -1,0 +1,33 @@
+on: [push, pull_request]
+
+name: R-CMD-check-docker
+
+jobs:
+  R-CMD-check-docker:
+    runs-on: ubuntu-latest
+    container: jakubnowosad/geocompr_proj6
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: r-lib/actions/setup-pandoc@master
+
+      - uses: r-lib/actions/setup-tinytex@master
+
+      - name: Install system dependencies
+        run: |
+          sudo add-apt-repository -y ppa:cran/v8
+          sudo apt-get -y update
+          sudo apt-get install -y libnode-dev
+
+      - name: Install dependencies
+        run: Rscript -e "install.packages('remotes')" -e "remotes::install_deps(dependencies = TRUE)" -e "remotes::install_cran('rcmdcheck')"
+
+      - name: Check${{ 
+        run: Rscript -e "rcmdcheck::rcmdcheck(args = '--as-cran --no-manual', error_on = 'warning', check_dir = 'check')"
+
+      - name: Upload check results
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: ${{ runner.os }}-docker-geocompr-results
+          path: check

--- a/.github/workflows/R-CMD-check-docker.yaml
+++ b/.github/workflows/R-CMD-check-docker.yaml
@@ -17,7 +17,7 @@ jobs:
         run: Rscript -e "install.packages('remotes')" -e "remotes::install_deps(dependencies = TRUE)" -e "remotes::install_cran('rcmdcheck')"
 
       - name: Check
-        run: Rscript -e "rcmdcheck::rcmdcheck(args = '--as-cran --no-manual', error_on = 'warning', check_dir = 'check')"
+        run: Rscript -e "rcmdcheck::rcmdcheck(args = '--no-manual', error_on = 'warning', check_dir = 'check')"
 
       - name: Upload check results
         if: failure()

--- a/.github/workflows/R-CMD-check-docker.yaml
+++ b/.github/workflows/R-CMD-check-docker.yaml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Install system dependencies
         run: |
+          sudo apt-get install -y software-properties-common
+          sudo apt-get -y update
           sudo add-apt-repository -y ppa:cran/v8
           sudo apt-get -y update
           sudo apt-get install -y libnode-dev

--- a/.github/workflows/R-CMD-check-docker.yaml
+++ b/.github/workflows/R-CMD-check-docker.yaml
@@ -9,10 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - uses: r-lib/actions/setup-pandoc@master
-
-      - uses: r-lib/actions/setup-tinytex@master
-
       - name: Install dependencies
         run: Rscript -e "install.packages('remotes')" -e "remotes::install_deps(dependencies = TRUE)" -e "remotes::install_cran('rcmdcheck')"
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,89 @@
+on: [push, pull_request]
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }} ${{ matrix.config.v8 }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - { os: windows-latest, r: '3.6', args: "--no-manual"}
+        - { os: macOS-latest, r: '3.6', args: "--no-manual"}
+        - { os: macOS-latest, r: 'devel'}
+        - { os: ubuntu-latest, r: '3.5', v8: "libnode-dev", args: "--no-manual"}
+        - { os: ubuntu-latest, r: '3.6', v8: "libv8-dev", args: "--no-manual"}
+        - { os: ubuntu-latest, r: '3.6', v8: "libnode-dev"}
+
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      CRAN: ${{ matrix.config.cran }}
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: r-lib/actions/setup-r@master
+        with:
+          r-version: ${{ matrix.config.r }}
+
+      - uses: r-lib/actions/setup-pandoc@master
+
+      - uses: r-lib/actions/setup-tinytex@master
+        if: contains(matrix.config.args, 'no-manual') == false
+
+      - name: Cache R packages
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-r-${{ matrix.config.r }}-v8-${{ matrix.config.v8 }}-${{ hashFiles('DESCRIPTION') }}
+
+
+      - name: install macOS system dependencies
+        if: runner.os == 'macOS' && matrix.config.r == 'devel'
+        continue-on-error: true
+        run: |
+          brew install pkg-config gdal openssl udunits v8 protobuf
+
+      - name: add modern cran/v8 ppa
+        # default libv8-dev on Xenial (16) and Bionic (18) is old libv8-3.14.5.
+        # To test on new, add the cran/v8 ppa and install current libnode-dev,
+        # To test on old, install libv8-dev from existing default ppa
+        if: runner.os == 'Linux' && contains(matrix.config.v8, 'libnode-dev') == true
+        run: |
+          sudo add-apt-repository -y ppa:cran/v8
+          sudo apt-get -y update
+
+      - name: Install system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
+          sudo add-apt-repository -y ppa:cran/jq
+          sudo apt-get -y update
+          sudo apt-get -y install libgdal-dev gdal-bin libgeos-dev \
+          libgeos++-dev git-core pandoc pandoc-citeproc libproj-dev libjq-dev \
+          libudunits2-dev libcurl4-openssl-dev libssl-dev libprotobuf-dev \
+          protobuf-compiler libprotoc-dev valgrind libpq-dev netcdf-bin\
+          ${{ matrix.config.v8 }}
+
+      - name: Install dependencies
+        run: Rscript -e "install.packages('remotes')" -e "remotes::install_deps(dependencies = TRUE)" -e "remotes::install_cran('rcmdcheck')"
+
+      - name: Check
+        run: Rscript -e "rcmdcheck::rcmdcheck(args = '${{ matrix.config.args }}', error_on = 'warning', check_dir = 'check')"
+
+      - name: Upload check results
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
+          path: check
+
+      - name: Test coverage
+        if: matrix.config.os == 'macOS-latest' && matrix.config.r == '3.6'
+        run: |
+          Rscript -e 'remotes::install_github("r-lib/covr@gh-actions")'
+          Rscript -e 'covr::codecov(token = "${{secrets.CODECOV_TOKEN}}")'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -43,10 +43,10 @@ jobs:
 
 
       - name: install macOS system dependencies
-        if: runner.os == 'macOS' && matrix.config.r == 'devel'
+        if: runner.os == 'macOS'
         continue-on-error: true
         run: |
-          brew install pkg-config gdal openssl udunits v8 protobuf
+          brew install pkg-config gdal openssl udunits v8 protobuf jq
 
       - name: add modern cran/v8 ppa
         # default libv8-dev on Xenial (16) and Bionic (18) is old libv8-3.14.5.
@@ -61,7 +61,6 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
-          sudo add-apt-repository -y ppa:cran/jq
           sudo apt-get -y update
           sudo apt-get -y install libgdal-dev gdal-bin libgeos-dev \
           libgeos++-dev git-core pandoc pandoc-citeproc libproj-dev libjq-dev \

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,12 +12,12 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { os: windows-latest, r: '3.6', args: "--no-manual"}
-        - { os: macOS-latest, r: '3.6', args: "--no-manual"}
+        - { os: windows-latest, r: 'release', args: "--no-manual"}
+        - { os: macOS-latest, r: 'release', args: "--no-manual"}
         - { os: macOS-latest, r: 'devel'}
         - { os: ubuntu-latest, r: '3.5', v8: "libnode-dev", args: "--no-manual"}
-        - { os: ubuntu-latest, r: '3.6', v8: "libv8-dev", args: "--no-manual"}
-        - { os: ubuntu-latest, r: '3.6', v8: "libnode-dev"}
+        - { os: ubuntu-latest, r: 'release', v8: "libv8-dev", args: "--no-manual"}
+        - { os: ubuntu-latest, r: 'release', v8: "libnode-dev"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -65,7 +65,7 @@ jobs:
           sudo apt-get -y install libgdal-dev gdal-bin libgeos-dev \
           libgeos++-dev git-core pandoc pandoc-citeproc libproj-dev libjq-dev \
           libudunits2-dev libcurl4-openssl-dev libssl-dev libprotobuf-dev \
-          protobuf-compiler libprotoc-dev valgrind libpq-dev netcdf-bin\
+          protobuf-compiler libprotoc-dev valgrind libpq-dev netcdf-bin \
           ${{ matrix.config.v8 }}
 
       - name: Install dependencies

--- a/README.Rmd
+++ b/README.Rmd
@@ -39,6 +39,7 @@ knitr::opts_chunk$set(
 
 [![cran checks](https://cranchecks.info/badges/worst/geojsonio)](https://cranchecks.info/pkgs/geojsonio)
 [![Build Status](https://api.travis-ci.org/ropensci/geojsonio.png)](https://travis-ci.org/ropensci/geojsonio)
+[![R build status](https://github.com/ropensci/geojsonio/workflows/R-CMD-check/badge.svg)](https://github.com/ropensci/geojsonio)
 [![codecov.io](https://codecov.io/github/ropensci/geojsonio/coverage.svg?branch=master)](https://codecov.io/github/ropensci/geojsonio?branch=master)
 [![rstudio mirror downloads](https://cranlogs.r-pkg.org/badges/geojsonio)](https://github.com/metacran/cranlogs.app)
 [![cran version](https://www.r-pkg.org/badges/version/geojsonio)](https://cran.r-project.org/package=geojsonio)


### PR DESCRIPTION
This is to add CI using GitHub actions. It checks the package on:

1. Using GitHub's built-in runners (https://github.com/ropensci/geojsonio/actions?query=workflow%3AR-CMD-check):
    - Windows using most recent R
    - macOS using most recent R
    - macOS using R-devel
    - Ubuntu using R 3.5
    - Ubuntu using most recent R
    - Ubuntu using most recent R and and old version of `libv8` (This may be overkill, but I found certain functionality in rmapshaper broke when built with older `libv8` (on Solaris)

2. Using the [`jakubnowosad/geocompr_proj6`](https://hub.docker.com/r/jakubnowosad/geocompr_proj6) docker image (https://github.com/ropensci/geojsonio/actions?query=workflow%3AR-CMD-check-docker): 
    - Linux with most recent R and new GDAL3 and PROJ6 . 
    - If there are other docker images you know of that would be good to check on (e.g., any of the Rocker images), it would be simple enough to add...