### PR TITLE
Explicitly set stringsAsFactors = TRUE in tests. #166

### DIFF
--- a/.github/workflows/R-CMD-check-docker.yaml
+++ b/.github/workflows/R-CMD-check-docker.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install system dependencies
         if: contains(matrix.config.image, 'rocker/r-ver:devel') == true
         run: |
-          apt-get update \
+          apt-get update 
           apt-get install -y --no-install-recommends \
           libgdal-dev gdal-bin libgeos-dev \
           libgeos++-dev git-core pandoc pandoc-citeproc libproj-dev libjq-dev \

--- a/.github/workflows/R-CMD-check-docker.yaml
+++ b/.github/workflows/R-CMD-check-docker.yaml
@@ -31,7 +31,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.config.image }}-${{ hashFiles('DESCRIPTION') }}
 
       - name: Install system dependencies
-        if: matrix.config.image == "rocker/r-ver:devel"
+        if: contains(matrix.config.image, 'rocker/r-ver:devel') == true
         run: |
           sudo apt-get -y update
           sudo apt-get -y install libgdal-dev gdal-bin libgeos-dev \

--- a/.github/workflows/R-CMD-check-docker.yaml
+++ b/.github/workflows/R-CMD-check-docker.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         config:
         - {image: "jakubnowosad/rspatial_proj6"}
-        - {image: "rocker/geospatial:devel"}
+        - {image: "rocker/r-ver:devel"}
         
     container: ${{ matrix.config.image }}
     
@@ -30,6 +30,16 @@ jobs:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ matrix.config.image }}-${{ hashFiles('DESCRIPTION') }}
 
+      - name: Install system dependencies
+        if: matrix.config.image == "rocker/r-ver:devel"
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install libgdal-dev gdal-bin libgeos-dev \
+          libgeos++-dev git-core pandoc pandoc-citeproc libproj-dev libjq-dev \
+          libudunits2-dev libcurl4-openssl-dev libssl-dev libprotobuf-dev \
+          protobuf-compiler libprotoc-dev valgrind libpq-dev netcdf-bin \
+          libnode-dev
+          
       - name: Install dependencies
         run: Rscript -e "install.packages('remotes')" -e "remotes::install_deps(dependencies = TRUE)" -e "remotes::install_cran('rcmdcheck')"
 

--- a/.github/workflows/R-CMD-check-docker.yaml
+++ b/.github/workflows/R-CMD-check-docker.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           apt-get update 
           apt-get install -y --no-install-recommends \
-          libgdal-dev gdal-bin libgeos-dev \
+          qpdf libgdal-dev gdal-bin libgeos-dev \
           libgeos++-dev git-core pandoc pandoc-citeproc libproj-dev libjq-dev \
           libudunits2-dev libcurl4-openssl-dev libssl-dev libprotobuf-dev \
           protobuf-compiler libprotoc-dev valgrind libpq-dev netcdf-bin \

--- a/.github/workflows/R-CMD-check-docker.yaml
+++ b/.github/workflows/R-CMD-check-docker.yaml
@@ -21,6 +21,12 @@ jobs:
       - uses: actions/checkout@v1
       
       - uses: r-lib/actions/setup-pandoc@master
+      
+      - name: Cache R packages
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ matrix.config.image }}-${{ hashFiles('DESCRIPTION') }}
 
       - name: Install dependencies
         run: Rscript -e "install.packages('remotes')" -e "remotes::install_deps(dependencies = TRUE)" -e "remotes::install_cran('rcmdcheck')"

--- a/.github/workflows/R-CMD-check-docker.yaml
+++ b/.github/workflows/R-CMD-check-docker.yaml
@@ -13,23 +13,14 @@ jobs:
       matrix:
         config:
         - {image: "jakubnowosad/rspatial_proj6"}
-        - {image: "rocker/r-devel"}
+        - {image: "rocker/geospatial:devel"}
         
     container: ${{ matrix.config.image }}
     
     steps:
       - uses: actions/checkout@v1
       
-      - name: Install system dependencies
-        if: contains(matrix.config.image, 'rocker/r-devel') == true
-        run: |
-          sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
-          sudo apt-get -y update
-          sudo apt-get -y install libgdal-dev gdal-bin libgeos-dev \
-          libgeos++-dev git-core pandoc pandoc-citeproc libproj-dev libjq-dev \
-          libudunits2-dev libcurl4-openssl-dev libssl-dev libprotobuf-dev \
-          protobuf-compiler libprotoc-dev valgrind libpq-dev netcdf-bin \
-          libnode-dev
+      - uses: r-lib/actions/setup-pandoc@master
 
       - name: Install dependencies
         run: Rscript -e "install.packages('remotes')" -e "remotes::install_deps(dependencies = TRUE)" -e "remotes::install_cran('rcmdcheck')"

--- a/.github/workflows/R-CMD-check-docker.yaml
+++ b/.github/workflows/R-CMD-check-docker.yaml
@@ -33,8 +33,9 @@ jobs:
       - name: Install system dependencies
         if: contains(matrix.config.image, 'rocker/r-ver:devel') == true
         run: |
-          sudo apt-get -y update
-          sudo apt-get -y install libgdal-dev gdal-bin libgeos-dev \
+          apt-get -y update \
+          apt-get -y install --no-install-recommends \
+          libgdal-dev gdal-bin libgeos-dev \
           libgeos++-dev git-core pandoc pandoc-citeproc libproj-dev libjq-dev \
           libudunits2-dev libcurl4-openssl-dev libssl-dev libprotobuf-dev \
           protobuf-compiler libprotoc-dev valgrind libpq-dev netcdf-bin \

--- a/.github/workflows/R-CMD-check-docker.yaml
+++ b/.github/workflows/R-CMD-check-docker.yaml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       
+      - uses: r-lib/actions/setup-r@master
+      
       - uses: r-lib/actions/setup-pandoc@master
       
       - name: Cache R packages

--- a/.github/workflows/R-CMD-check-docker.yaml
+++ b/.github/workflows/R-CMD-check-docker.yaml
@@ -33,8 +33,8 @@ jobs:
       - name: Install system dependencies
         if: contains(matrix.config.image, 'rocker/r-ver:devel') == true
         run: |
-          apt-get -y update \
-          apt-get -y install --no-install-recommends \
+          apt-get update \
+          apt-get install -y --no-install-recommends \
           libgdal-dev gdal-bin libgeos-dev \
           libgeos++-dev git-core pandoc pandoc-citeproc libproj-dev libjq-dev \
           libudunits2-dev libcurl4-openssl-dev libssl-dev libprotobuf-dev \

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,7 +41,6 @@ jobs:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-r-${{ matrix.config.r }}-v8-${{ matrix.config.v8 }}-${{ hashFiles('DESCRIPTION') }}
 
-
       - name: install macOS system dependencies
         if: runner.os == 'macOS'
         continue-on-error: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -60,8 +60,9 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
-          sudo apt-get -y update
-          sudo apt-get -y install libgdal-dev gdal-bin libgeos-dev \
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+          qpdf libgdal-dev gdal-bin libgeos-dev \
           libgeos++-dev git-core pandoc pandoc-citeproc libproj-dev libjq-dev \
           libudunits2-dev libcurl4-openssl-dev libssl-dev libprotobuf-dev \
           protobuf-compiler libprotoc-dev valgrind libpq-dev netcdf-bin \

--- a/tests/testthat/test-topojson_read.R
+++ b/tests/testthat/test-topojson_read.R
@@ -2,7 +2,7 @@ context("topojson_read")
 
 test_that("topojson_read works with file inputs", {
   file <- system.file("examples", "us_states.topojson", package = "geojsonio")
-  aa <- topojson_read(file, quiet = TRUE)
+  aa <- topojson_read(file, quiet = TRUE, stringsAsFactors = TRUE)
   df <- as.data.frame(aa)
   
   expect_is(aa, "sf")


### PR DESCRIPTION
This is a fix for #166, just by setting `stringsAsFactors = TRUE` in the test. We could also expose `stringsAsFactors` in [`topojson_read()`](https://github.com/ropensci/geojsonio/blob/b850ff600d4f1932c7198fd5583d983a1bc1e117/R/topojson_read.R) (default `FALSE`), which might be friendly to users? It can currently be set in `...` and sent through to to `sf::st_read()`.