### PR TITLE
sf CRS fixes

### DIFF
--- a/R/crs_convert.R
+++ b/R/crs_convert.R
@@ -38,7 +38,7 @@ convert_wgs84_sf_sfc <- function(x, crs) {
   if (!requireNamespace("sf", quietly = TRUE)) {
     stop("You don't have the 'sf' package installed. Please install and try again")
   } else {
-    message("Converting CRS from EPSG:", sf::st_crs(x)[["epsg"]], " to WGS84.")
+    message("Converting CRS from EPSG:", sf::st_crs(x)$epsg, " to WGS84.")
     sf::st_transform(x, 4326)
   }
 }
@@ -51,10 +51,10 @@ is_wgs84.sf <- function(x, warn = TRUE) {
 }
 
 is_wgs84.sfc <- function(x, warn = TRUE) {
-  crs_attr <- attr(x, "crs")
-  epsg <- crs_attr[["epsg"]]
+  crs_attr <- st_crs(x)
+  epsg <- crs_attr$epsg
   if (is.na(epsg)) {
-    is_it <- is_wgs84_proj4(crs_attr[["proj4string"]])
+    is_it <- is_wgs84_proj4(crs_attr$proj4string)
   } else {
     is_it <- epsg == 4326
   }

--- a/tests/testthat/test-crs_convert.R
+++ b/tests/testthat/test-crs_convert.R
@@ -1,172 +1,172 @@
 context("detect and convert crs")
 
-# sm <- function(x) suppressMessages(x)
+sm <- function(x) suppressMessages(x)
 
-# compare_things <- function(a, b) {
-#   a$name <- b$name <- NULL
-#   expect_equal(a, b)
-# }
+compare_things <- function(a, b) {
+  a$name <- b$name <- NULL
+  expect_equal(a, b)
+}
 
-# if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
+if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
 
-#   suppressPackageStartupMessages(library(sp))
+  suppressPackageStartupMessages(library(sp))
 
-#   sfc <-  st_sfc(st_point(c(0,0)), st_point(c(1,1)))
-#   sf <-  st_sf(a = 1:2, geom = sfc)
-#   sf_4326 <- st_set_crs(sf, 4326)
-#   sf_3005 <- st_transform(sf_4326, 3005)
+  sfc <-  st_sfc(st_point(c(0,0)), st_point(c(1,1)))
+  sf <-  st_sf(a = 1:2, geom = sfc)
+  sf_4326 <- st_set_crs(sf, 4326)
+  sf_3005 <- st_transform(sf_4326, 3005)
 
-#   pts = cbind(1:5, 1:5)
-#   df = data.frame(a = 1:5)
-#   spdf <- spdf_4326 <- spdf_3005 <- SpatialPointsDataFrame(pts, df)
-#   proj4string(spdf_4326) <- CRS("+init=epsg:4326")
-#   spdf_3005 <- supw(as(sf::st_transform(sf::st_as_sf(spdf_4326), 3005), 'Spatial'))
+  pts = cbind(1:5, 1:5)
+  df = data.frame(a = 1:5)
+  spdf <- spdf_4326 <- spdf_3005 <- SpatialPointsDataFrame(pts, df)
+  proj4string(spdf_4326) <- CRS("+init=epsg:4326")
+  spdf_3005 <- supw(as(sf::st_transform(sf::st_as_sf(spdf_4326), 3005), 'Spatial'))
 
-#   test_that("works with sf", {
-#     expect_is(st_crs(convert_wgs84(sf_4326))[["proj4string"]],
-#               "character")
+  test_that("works with sf", {
+    expect_is(st_crs(convert_wgs84(sf_4326))$proj4string,
+              "character")
 
-#     expect_is(st_crs(sm(convert_wgs84(sf_3005)))[["proj4string"]],
-#                  "character")
-#   })
+    expect_is(st_crs(sm(convert_wgs84(sf_3005)))$proj4string,
+                 "character")
+  })
 
-#   test_that("works with sfc", {
-#     suppressWarnings(st_crs(sfc) <-  4326)
-#     expect_is(st_crs(sm(convert_wgs84(sfc)))[["proj4string"]],
-#                  "character")
+  test_that("works with sfc", {
+    suppressWarnings(st_crs(sfc) <-  4326)
+    expect_is(st_crs(sm(convert_wgs84(sfc)))$proj4string,
+                 "character")
 
-#     suppressWarnings(st_crs(sfc) <- 3005)
-#     expect_is(st_crs(sm(convert_wgs84(sfc)))[["proj4string"]],
-#                  "character")
-#   })
+    suppressWarnings(st_crs(sfc) <- 3005)
+    expect_is(st_crs(sm(convert_wgs84(sfc)))$proj4string,
+                 "character")
+  })
 
-#   test_that("works with spatial", {
-#     expect_is(proj4string(convert_wgs84(spdf_4326)),
-#                  "character")
+  test_that("works with spatial", {
+    expect_is(proj4string(convert_wgs84(spdf_4326)),
+                 "character")
 
-#     expect_is(proj4string(convert_wgs84(spdf_3005)),
-#                  "character")
-#   })
+    expect_is(proj4string(convert_wgs84(spdf_3005)),
+                 "character")
+  })
 
-#   test_that("allows supplying a CRS with Spatial", {
-#     expect_is(proj4string(convert_wgs84(spdf, crs = "+init=epsg:3005")),
-#                  "character")
-#   })
+  test_that("allows supplying a CRS with Spatial", {
+    expect_is(proj4string(convert_wgs84(spdf, crs = "+init=epsg:3005")),
+                 "character")
+  })
 
-#   test_that("allows supplying a CRS with sf", {
-#     expect_is(st_crs(convert_wgs84(sf, crs = 3005))[["proj4string"]],
-#                  "character")
-#   })
+  test_that("allows supplying a CRS with sf", {
+    expect_is(st_crs(convert_wgs84(sf, crs = 3005))$proj4string,
+                 "character")
+  })
 
-#   test_that("allows supplying a CRS with sfc", {
-#     expect_is(st_crs(convert_wgs84(sfc, crs = 3005))[["proj4string"]],
-#                  "character")
-#   })
+  test_that("allows supplying a CRS with sfc", {
+    expect_is(st_crs(convert_wgs84(sfc, crs = 3005))$proj4string,
+                 "character")
+  })
 
-#   test_that("is_wgs84 works with sf", {
-#     expect_true(is_wgs84(sf_4326))
-#     expect_false(suppressWarnings(is_wgs84(sf_3005)))
-#     expect_warning(is_wgs84(sf_3005), "WGS84")
-#   })
+  test_that("is_wgs84 works with sf", {
+    expect_true(is_wgs84(sf_4326))
+    expect_false(suppressWarnings(is_wgs84(sf_3005)))
+    expect_warning(is_wgs84(sf_3005), "WGS84")
+  })
 
-#   test_that("is_wgs84 works with sfc", {
-#     st_crs(sfc) <- 4326
-#     expect_true(is_wgs84(sfc))
-#     sfc_3005 <- st_transform(sfc, 3005)
-#     expect_false(suppressWarnings(is_wgs84(sfc_3005)))
-#     expect_warning(is_wgs84(sfc_3005), "WGS84")
-#   })
+  test_that("is_wgs84 works with sfc", {
+    st_crs(sfc) <- 4326
+    expect_true(is_wgs84(sfc))
+    sfc_3005 <- st_transform(sfc, 3005)
+    expect_false(suppressWarnings(is_wgs84(sfc_3005)))
+    expect_warning(is_wgs84(sfc_3005), "WGS84")
+  })
 
-#   test_that("is_wgs84 works with Spatial", {
-#     proj4string(spdf) <- "+init=epsg:4326"
-#     expect_true(is_wgs84(spdf))
-#     spdf_3005 <- supw(as(sf::st_transform(sf::st_as_sf(spdf), 3005), 'Spatial'))
-#     expect_false(suppressWarnings(is_wgs84(spdf_3005)))
-#     expect_warning(is_wgs84(spdf_3005), "WGS84")
-#   })
+  test_that("is_wgs84 works with Spatial", {
+    proj4string(spdf) <- "+init=epsg:4326"
+    expect_true(is_wgs84(spdf))
+    spdf_3005 <- supw(as(sf::st_transform(sf::st_as_sf(spdf), 3005), 'Spatial'))
+    expect_false(suppressWarnings(is_wgs84(spdf_3005)))
+    expect_warning(is_wgs84(spdf_3005), "WGS84")
+  })
 
-#   test_that("geojson_list: convert_wgs84 works with Spatial classes", {
-#     compare_things(
-#       geojson_list(spdf_4326, convert_wgs84 = TRUE),
-#       geojson_list(spdf_4326, convert_wgs84 = FALSE)
-#     )
-#     compare_things(geojson_list(spdf_4326),
-#       geojson_list(spdf_3005, convert_wgs84 = TRUE))
-#     proj4string(spdf_3005) <- NA_character_
-#     compare_things(geojson_list(spdf_4326),
-#       geojson_list(spdf_3005, convert_wgs84 = TRUE, crs = "+init=epsg:3005"))
-#     compare_things(geojson_list(spdf_4326),
-#       geojson_list(spdf_3005, convert_wgs84 = TRUE, crs = 3005))
-#   })
+  test_that("geojson_list: convert_wgs84 works with Spatial classes", {
+    compare_things(
+      geojson_list(spdf_4326, convert_wgs84 = TRUE),
+      geojson_list(spdf_4326, convert_wgs84 = FALSE)
+    )
+    compare_things(geojson_list(spdf_4326),
+      geojson_list(spdf_3005, convert_wgs84 = TRUE))
+    proj4string(spdf_3005) <- NA_character_
+    compare_things(geojson_list(spdf_4326),
+      geojson_list(spdf_3005, convert_wgs84 = TRUE, crs = "+init=epsg:3005"))
+    compare_things(geojson_list(spdf_4326),
+      geojson_list(spdf_3005, convert_wgs84 = TRUE, crs = 3005))
+  })
 
-#   test_that("geojson_list: convert_wgs84 works with sf classes", {
-#     expect_equal(geojson_list(sf_4326, convert_wgs84 = TRUE),
-#                  geojson_list(sf_4326, convert_wgs84 = FALSE))
-#     expect_equal(geojson_list(sf_4326),
-#                  geojson_list(sf_3005, convert_wgs84 = TRUE))
-#     st_crs(sf_3005) <- NA_crs_
-#     expect_equal(geojson_list(sf_4326),
-#                  geojson_list(sf_3005, convert_wgs84 = TRUE, crs = "+init=epsg:3005"))
-#     expect_equal(geojson_list(sf_4326),
-#                  geojson_list(sf_3005, convert_wgs84 = TRUE, crs = 3005))
-#   })
+  test_that("geojson_list: convert_wgs84 works with sf classes", {
+    expect_equal(geojson_list(sf_4326, convert_wgs84 = TRUE),
+                 geojson_list(sf_4326, convert_wgs84 = FALSE))
+    expect_equal(geojson_list(sf_4326),
+                 geojson_list(sf_3005, convert_wgs84 = TRUE))
+    st_crs(sf_3005) <- NA_crs_
+    expect_equal(geojson_list(sf_4326),
+                 geojson_list(sf_3005, convert_wgs84 = TRUE, crs = "+init=epsg:3005"))
+    expect_equal(geojson_list(sf_4326),
+                 geojson_list(sf_3005, convert_wgs84 = TRUE, crs = 3005))
+  })
 
-#   test_that("geojson_json: convert_wgs84 works with Spatial classes", {
-#     compare_things(geojson_list(geojson_json(spdf_4326, convert_wgs84 = TRUE)),
-#                  geojson_list(geojson_json(spdf_4326, convert_wgs84 = FALSE)))
-#     compare_things(geojson_list(geojson_json(spdf_4326)),
-#                  geojson_list(geojson_json(spdf_3005, convert_wgs84 = TRUE)))
-#     proj4string(spdf_3005) <- NA_character_
-#     compare_things(geojson_list(geojson_json(spdf_4326)),
-#                  geojson_list(geojson_json(spdf_3005,
-#                                            convert_wgs84 = TRUE,
-#                                            crs = "+init=epsg:3005")))
-#     compare_things(geojson_list(geojson_json(spdf_4326)),
-#                  geojson_list(geojson_json(spdf_3005, convert_wgs84 = TRUE, crs = 3005)))
-#   })
+  test_that("geojson_json: convert_wgs84 works with Spatial classes", {
+    compare_things(geojson_list(geojson_json(spdf_4326, convert_wgs84 = TRUE)),
+                 geojson_list(geojson_json(spdf_4326, convert_wgs84 = FALSE)))
+    compare_things(geojson_list(geojson_json(spdf_4326)),
+                 geojson_list(geojson_json(spdf_3005, convert_wgs84 = TRUE)))
+    proj4string(spdf_3005) <- NA_character_
+    compare_things(geojson_list(geojson_json(spdf_4326)),
+                 geojson_list(geojson_json(spdf_3005,
+                                           convert_wgs84 = TRUE,
+                                           crs = "+init=epsg:3005")))
+    compare_things(geojson_list(geojson_json(spdf_4326)),
+                 geojson_list(geojson_json(spdf_3005, convert_wgs84 = TRUE, crs = 3005)))
+  })
 
-#   test_that("geojson_json: convert_wgs84 works with sf classes", {
-#     expect_equal(geojson_list(geojson_json(sf_4326, convert_wgs84 = TRUE)),
-#                  geojson_list(geojson_json(sf_4326, convert_wgs84 = FALSE)))
-#     expect_equal(geojson_list(geojson_json(sf_4326)),
-#                  geojson_list(geojson_json(sf_3005, convert_wgs84 = TRUE)))
-#     st_crs(sf_3005) <- NA_crs_
-#     expect_equal(geojson_list(geojson_json(sf_4326)),
-#                  geojson_list(geojson_json(sf_3005,
-#                                            convert_wgs84 = TRUE,
-#                                            crs = "+init=epsg:3005")))
-#     expect_equal(geojson_list(geojson_json(sf_4326)),
-#                  geojson_list(geojson_json(sf_3005, convert_wgs84 = TRUE, crs = 3005)))
-#   })
+  test_that("geojson_json: convert_wgs84 works with sf classes", {
+    expect_equal(geojson_list(geojson_json(sf_4326, convert_wgs84 = TRUE)),
+                 geojson_list(geojson_json(sf_4326, convert_wgs84 = FALSE)))
+    expect_equal(geojson_list(geojson_json(sf_4326)),
+                 geojson_list(geojson_json(sf_3005, convert_wgs84 = TRUE)))
+    st_crs(sf_3005) <- NA_crs_
+    expect_equal(geojson_list(geojson_json(sf_4326)),
+                 geojson_list(geojson_json(sf_3005,
+                                           convert_wgs84 = TRUE,
+                                           crs = "+init=epsg:3005")))
+    expect_equal(geojson_list(geojson_json(sf_4326)),
+                 geojson_list(geojson_json(sf_3005, convert_wgs84 = TRUE, crs = 3005)))
+  })
 
-#   file_to_list <- function(x) geojson_read(x$path, what = "list")
+  file_to_list <- function(x) geojson_read(x$path, what = "list")
 
-#   test_that("geojson_write: convert_wgs84 works with Spatial classes", {
-#     expect_equal(file_to_list(geojson_write(spdf_4326, convert_wgs84 = TRUE))$crs,
-#                  file_to_list(geojson_write(spdf_4326, convert_wgs84 = FALSE))$crs)
-#     expect_equal(file_to_list(geojson_write(spdf_4326))$crs,
-#                  file_to_list(geojson_write(spdf_3005, convert_wgs84 = TRUE))$crs)
-#     proj4string(spdf_3005) <- NA_character_
-#     expect_equal(file_to_list(geojson_write(spdf_4326))$crs,
-#                  file_to_list(geojson_write(spdf_3005,
-#                                             convert_wgs84 = TRUE,
-#                                             crs = "+init=epsg:3005"))$crs)
-#     expect_equal(file_to_list(geojson_write(spdf_4326))$crs,
-#                  file_to_list(geojson_write(spdf_3005, convert_wgs84 = TRUE, crs = 3005))$crs)
-#   })
+  test_that("geojson_write: convert_wgs84 works with Spatial classes", {
+    expect_equal(file_to_list(geojson_write(spdf_4326, convert_wgs84 = TRUE))$crs,
+                 file_to_list(geojson_write(spdf_4326, convert_wgs84 = FALSE))$crs)
+    expect_equal(file_to_list(geojson_write(spdf_4326))$crs,
+                 file_to_list(geojson_write(spdf_3005, convert_wgs84 = TRUE))$crs)
+    proj4string(spdf_3005) <- NA_character_
+    expect_equal(file_to_list(geojson_write(spdf_4326))$crs,
+                 file_to_list(geojson_write(spdf_3005,
+                                            convert_wgs84 = TRUE,
+                                            crs = "+init=epsg:3005"))$crs)
+    expect_equal(file_to_list(geojson_write(spdf_4326))$crs,
+                 file_to_list(geojson_write(spdf_3005, convert_wgs84 = TRUE, crs = 3005))$crs)
+  })
 
-#   test_that("geojson_write: convert_wgs84 works with sf classes", {
-#     expect_equal(file_to_list(geojson_write(sf_4326, convert_wgs84 = TRUE))$crs,
-#                  file_to_list(geojson_write(sf_4326, convert_wgs84 = FALSE))$crs)
-#     expect_equal(file_to_list(geojson_write(sf_4326))$crs,
-#                  file_to_list(geojson_write(sf_3005, convert_wgs84 = TRUE))$crs)
-#     st_crs(sf_3005) <- NA_crs_
-#     expect_equal(file_to_list(geojson_write(sf_4326))$crs,
-#                  file_to_list(geojson_write(sf_3005,
-#                                             convert_wgs84 = TRUE,
-#                                             crs = "+init=epsg:3005"))$crs)
-#     expect_equal(file_to_list(geojson_write(sf_4326))$crs,
-#                  file_to_list(geojson_write(sf_3005, convert_wgs84 = TRUE, crs = 3005))$crs)
-#   })
+  test_that("geojson_write: convert_wgs84 works with sf classes", {
+    expect_equal(file_to_list(geojson_write(sf_4326, convert_wgs84 = TRUE))$crs,
+                 file_to_list(geojson_write(sf_4326, convert_wgs84 = FALSE))$crs)
+    expect_equal(file_to_list(geojson_write(sf_4326))$crs,
+                 file_to_list(geojson_write(sf_3005, convert_wgs84 = TRUE))$crs)
+    st_crs(sf_3005) <- NA_crs_
+    expect_equal(file_to_list(geojson_write(sf_4326))$crs,
+                 file_to_list(geojson_write(sf_3005,
+                                            convert_wgs84 = TRUE,
+                                            crs = "+init=epsg:3005"))$crs)
+    expect_equal(file_to_list(geojson_write(sf_4326))$crs,
+                 file_to_list(geojson_write(sf_3005, convert_wgs84 = TRUE, crs = 3005))$crs)
+  })
 
-# }
+}


### PR DESCRIPTION
Address #159:

- Don't access crs directly with `attrs()`, rather always use `st_crs()`
- Don't access crs slots with `[[`, rather use the `$` methods.