### PR TITLE
Remove unnecessary unlink to avoid warnings in R 4.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Convert data to 'GeoJSON' or 'TopoJSON' from various R classes,
     'geojsonio' does not aim to replace packages like 'sp', 'rgdal', 'rgeos',
     but rather aims to be a high level client to simplify conversions of data
     from and to 'GeoJSON' and 'TopoJSON'.
-Version: 0.9.4.91
+Version: 0.9.4.92
 License: MIT + file LICENSE
 Authors@R: c(
     person("Scott", "Chamberlain", role = c("aut", "cre"), email = "myrmecocystus@gmail.com"),

--- a/R/geojson_read.R
+++ b/R/geojson_read.R
@@ -170,7 +170,6 @@ file_to_sp <- function(input, stringsAsFactors = FALSE, ...) {
 
 sf2list <- function(x, parse) {
   stopifnot(inherits(x, "sf"))
-  on.exit(unlink(x))
   txt <- geojsonsf::sf_geojson(x)
   jsonlite::fromJSON(txt, parse)
 }


### PR DESCRIPTION
## Description
On R 4.2 `geojson::geojson_read` is returning a warning for all files

```
Warning (test-geojson_read.R:10:3): geojson_read works with file inputs
expanded path length 35145 would be too long for
list(list(list(c(-120.248484, -120.247393, -120.238657, -120.230001, -120.221287, -120.208478, -120.19578, -120.167306, -120.151663, -120.147647, -120.140362, -120.135853, -120.115058, -120.090182, -120.073609, -120.062778, -120.061953, -120.057637, -120.055107, -120.043259, -120.044004, -120.047798, -120.050382, -120.048926, -120.046575, -120.041311, -120.025653, -120.011123, -120.003815, -119.984316, -119.978876, -119.979913, -119.976857, -119.971141, -119.97026, -119.973691, -120.00096, -120.017715, 
-120.046881, -120.048315, -120.048611, -120.049682, -120.077793, -120.098601, -120.105489, -120.109137, -120.121817, -120.168974, -120.179049, -120.18984, -120.192339, -120.198602, -120.200085, -120.209372, -120.224461, -120.248484, 33.999329, 34.001911, 34.007592, 34.010136, 34.010367, 34.005655, 34.004284, 34.008219, 34.018126, 34.024831, 34.025974, 34.026087, 34.019866, 34.019806, 34.024477, 34.031161, 34.033976, 34.03734, 34.037729, 3 [... truncated]
Backtrace:
 1. geojsonio::geojson_read(file)
      at test-geojson_read.R:10:2
 2. geojsonio::geojson_read.character(file)
      at geojsonio/R/geojson_read.R:89:2
 3. geojsonio::read_json(...)
      at geojsonio/R/geojson_read.R:101:2
 4. geojsonio::file_to_list(x, stringsAsFactors, parse, ...)
      at geojsonio/R/geojson_read.R:133:2
 5. geojsonio::tosp_list(input, stringsAsFactors, parse, ...)
      at geojsonio/R/geojson_read.R:144:2
 6. geojsonio::sf2list(tosp_base(x, stringsAsFactors, ...), parse)
      at geojsonio/R/geojson_read.R:179:2
 7. base::unlink(x)
      at geojsonio/R/geojson_read.R:179:2
```

Looking at the PR which added this `unlink` call https://github.com/ropensci/geojsonio/commit/3dbd4c8da07dceda3517a0bac107e004c208ada8#diff-8612e05a9f8ba5a657c0697ef0ec3a3bd59277ff8a2220d4b277ad8b9942c688R119 I think this was meant to be called on the tempfile `tfile` (references to which have since been removed).

## Related Issue
None

## Example
```
file <- system.file("examples", "california.geojson", package = "geojsonio")
aa <- geojson_read(as.location(file))
```

No test here - I can write an explicit test to check that the warning about "expanded path length" is not raised if it would be helpful.
