### PR TITLE
Testthat 3e: better test isolation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,8 @@ Suggests:
     leaflet,
     maps,
     RPostgres,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    withr
 Enhances: 
     RColorBrewer
 Encoding: UTF-8

--- a/README.Rmd
+++ b/README.Rmd
@@ -21,6 +21,7 @@ knitr::opts_chunk$set(
 [![codecov.io](https://codecov.io/github/ropensci/geojsonio/coverage.svg?branch=main)](https://codecov.io/github/ropensci/geojsonio?branch=main)
 [![rstudio mirror downloads](https://cranlogs.r-pkg.org/badges/geojsonio)](https://github.com/r-hub/cranlogs.app)
 [![cran version](https://www.r-pkg.org/badges/version/geojsonio)](https://cran.r-project.org/package=geojsonio)
+[![Project Status: Inactive – The project has reached a stable, usable state but is no longer being actively developed; support/maintenance will be provided as time allows.](https://www.repostatus.org/badges/latest/inactive.svg)](https://www.repostatus.org/#inactive)
 <!-- badges: end -->
 
 ```{r echo=FALSE}
@@ -138,6 +139,25 @@ remotes::install_github("ropensci/geojsonio")
 ```{r}
 library("geojsonio")
 ```
+
+## What's the future of geojsonio?
+
+geojsonio is stable and we expect it to stay on CRAN. The package is a 
+dependency for a number of other packages and is downloaded tens of thousands
+of times per month; moving forward the priority with this package is to make 
+sure that those packages and users are able to keep using the package.
+
+That said, we do not anticipate much further development; there will not likely
+be many major new features added or new interfaces developed. We'll avoid 
+making breaking changes as much as possible (though we do anticipate deprecating
+rgeos-based features and removing rgeos and maptools code, in line with those 
+packages' deprecation).
+
+If you find bugs in geojsonio or want to contribute new features: please feel
+free to submit PRs! So long as the existing interface stays intact, we'd be
+more than happy to make the package more useful for you. That said, we don't 
+anticipate being particularly responsive to feature requests 
+(without a matching PR) moving forward.
 
 ## Meta
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ checks](https://cranchecks.info/badges/worst/geojsonio)](https://cranchecks.info
 downloads](https://cranlogs.r-pkg.org/badges/geojsonio)](https://github.com/r-hub/cranlogs.app)
 [![cran
 version](https://www.r-pkg.org/badges/version/geojsonio)](https://cran.r-project.org/package=geojsonio)
+[![Project Status: Inactive – The project has reached a stable, usable
+state but is no longer being actively developed; support/maintenance
+will be provided as time
+allows.](https://www.repostatus.org/badges/latest/inactive.svg)](https://www.repostatus.org/#inactive)
 <!-- badges: end -->
 
 **Convert various data formats to GeoJSON or TopoJSON**
@@ -109,6 +113,26 @@ remotes::install_github("ropensci/geojsonio")
 ``` r
 library("geojsonio")
 ```
+
+## What’s the future of geojsonio?
+
+geojsonio is stable and we expect it to stay on CRAN. The package is a
+dependency for a number of other packages and is downloaded tens of
+thousands of times per month; moving forward the priority with this
+package is to make sure that those packages and users are able to keep
+using the package.
+
+That said, we do not anticipate much further development; there will not
+likely be many major new features added or new interfaces developed.
+We’ll avoid making breaking changes as much as possible (though we do
+anticipate deprecating rgeos-based features and removing rgeos and
+maptools code, in line with those packages’ deprecation).
+
+If you find bugs in geojsonio or want to contribute new features: please
+feel free to submit PRs! So long as the existing interface stays intact,
+we’d be more than happy to make the package more useful for you. That
+said, we don’t anticipate being particularly responsive to feature
+requests (without a matching PR) moving forward.
 
 ## Meta
 

--- a/tests/testthat/helper-geojsonio.R
+++ b/tests/testthat/helper-geojsonio.R
@@ -43,3 +43,7 @@ temp_map_gist <- function(..., envir = parent.frame()) {
   )
   g
 }
+
+example_sys_file <- function(...) {
+  system.file("examples", ..., package = "geojsonio", mustWork = TRUE)
+}

--- a/tests/testthat/helper-geojsonio.R
+++ b/tests/testthat/helper-geojsonio.R
@@ -26,3 +26,5 @@ num_digits <- function(x) {
   if ("geometries" %in% names(z)) w <- unlist(z$geometries$coordinates)
   decimalnumcount(as.character(w))
 }
+
+supp_invis <- function(x) suppressMessages(invisible(x))

--- a/tests/testthat/helper-geojsonio.R
+++ b/tests/testthat/helper-geojsonio.R
@@ -1,8 +1,5 @@
-gdel <- function(x) {
-  invisible(gistr::delete(x))
-}
-
-supw <- function(x) suppressWarnings(x)
+supm <- function(x) invisible(suppressMessages(x))
+supw <- function(x) invisible(suppressWarnings(x))
 
 # functions for precision testing
 # modified from https://stat.ethz.ch/pipermail/r-help/2012-July/317676.html
@@ -20,11 +17,10 @@ decimalnumcount <- function(x) {
   }
   return(vec)
 }
+
 num_digits <- function(x) {
   z <- jsonlite::fromJSON(unclass(x)[[1]])
   if ("features" %in% names(z)) w <- unlist(z$features$geometry$coordinates)
   if ("geometries" %in% names(z)) w <- unlist(z$geometries$coordinates)
   decimalnumcount(as.character(w))
 }
-
-supp_invis <- function(x) suppressMessages(invisible(x))

--- a/tests/testthat/helper-geojsonio.R
+++ b/tests/testthat/helper-geojsonio.R
@@ -24,3 +24,22 @@ num_digits <- function(x) {
   if ("geometries" %in% names(z)) w <- unlist(z$geometries$coordinates)
   decimalnumcount(as.character(w))
 }
+
+## temporary gist helpers
+
+local_gist_temp_file <- function(envir = parent.frame()) {
+  withr::local_tempfile(
+    pattern = "geojsonio_test_",
+    fileext = ".geojson",
+    .local_envir = envir
+  )
+}
+
+temp_map_gist <- function(..., envir = parent.frame()) {
+  g <- supm(map_gist(...))
+  withr::defer(
+    supm(gistr::delete(g)),
+    envir = envir
+  )
+  g
+}

--- a/tests/testthat/teardown.R
+++ b/tests/testthat/teardown.R
@@ -1,1 +1,0 @@
-suppressWarnings(unlink("myfile.geojson"))

--- a/tests/testthat/teardown.R
+++ b/tests/testthat/teardown.R
@@ -1,2 +1,1 @@
 suppressWarnings(unlink("myfile.geojson"))
-suppressWarnings(unlink("myfile.topojson"))

--- a/tests/testthat/test-as.json.R
+++ b/tests/testthat/test-as.json.R
@@ -20,7 +20,7 @@ test_that("as.json works with geo_list class inputs", {
 test_that("as.json works with data.frame class inputs", {
   skip_on_cran()
 
-  tf1 <- tempfile(fileext = ".geojson")
+  tf1 <- withr::local_tempfile(fileext = ".geojson")
   cc <- suppressMessages(geojson_write(us_cities[1:2, ], lat = "lat", lon = "long", file = tf1))
   expect_s3_class(cc, "geojson_file")
   expect_type(unclass(cc), "list")
@@ -30,7 +30,7 @@ test_that("as.json works with data.frame class inputs", {
     "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"name\":\"Abilene TX\",\"country.etc\":\"TX\",\"pop\":113888,\"lat\":32.45,\"long\":-99.74,\"capital\":0},\"geometry\":{\"type\":\"Point\",\"coordinates\":[-99.74,32.45]}},{\"type\":\"Feature\",\"properties\":{\"name\":\"Akron OH\",\"country.etc\":\"OH\",\"pop\":206634,\"lat\":41.08,\"long\":-81.52,\"capital\":0},\"geometry\":{\"type\":\"Point\",\"coordinates\":[-81.52,41.08]}}]}"
   )
 
-  tf11 <- tempfile(fileext = ".geojson")
+  tf11 <- withr::local_tempfile(fileext = ".geojson")
   d <- supw(suppressMessages(geojson_write(
     input = states, lat = "lat", lon = "long",
     geometry = "polygon", group = "group", file = tf11
@@ -53,7 +53,7 @@ test_that("as.json works with geojson class inputs", {
     c(30, 40, 35, 30)
   ))), "2")
   sp_poly <- SpatialPolygons(list(poly1, poly2), 1:2)
-  tf2 <- tempfile(fileext = ".geojson")
+  tf2 <- withr::local_tempfile(fileext = ".geojson")
   e <- suppressMessages(geojson_write(sp_poly, file = tf2))
   expect_s3_class(e, "geojson_file")
   expect_type(unclass(e), "list")
@@ -89,7 +89,7 @@ test_that("as.json works with topojson list inputs", {
 test_that("as.json works with file name inputs", {
   skip_on_cran()
 
-  tf3 <- tempfile(fileext = ".geojson")
+  tf3 <- withr::local_tempfile(fileext = ".geojson")
   ee <- suppressMessages(geojson_write(us_cities[1:2, ], lat = "lat", lon = "long", file = tf3))
   expect_s3_class(ee, "geojson_file")
   expect_type(unclass(ee), "list")

--- a/tests/testthat/test-as.json.R
+++ b/tests/testthat/test-as.json.R
@@ -44,7 +44,6 @@ test_that("as.json works with data.frame class inputs", {
 test_that("as.json works with geojson class inputs", {
   skip_on_cran()
 
-  library("sp")
   poly1 <- Polygons(list(Polygon(cbind(
     c(-100, -90, -85, -100),
     c(40, 50, 45, 40)
@@ -68,7 +67,6 @@ test_that("as.json works with geojson class inputs", {
 test_that("as.json works with topojson list inputs", {
   skip_on_cran()
 
-  library("sp")
   z <- SpatialPolygonsDataFrame(
     SpatialPolygons(list(
       Polygons(list(

--- a/tests/testthat/test-as.json.R
+++ b/tests/testthat/test-as.json.R
@@ -21,7 +21,9 @@ test_that("as.json works with data.frame class inputs", {
   skip_on_cran()
 
   tf1 <- withr::local_tempfile(fileext = ".geojson")
-  cc <- suppressMessages(geojson_write(us_cities[1:2, ], lat = "lat", lon = "long", file = tf1))
+  cc <- supm(
+    geojson_write(us_cities[1:2, ], lat = "lat", lon = "long", file = tf1)
+  )
   expect_s3_class(cc, "geojson_file")
   expect_type(unclass(cc), "list")
   expect_s3_class(as.json(cc), "json")
@@ -31,7 +33,7 @@ test_that("as.json works with data.frame class inputs", {
   )
 
   tf11 <- withr::local_tempfile(fileext = ".geojson")
-  d <- supw(suppressMessages(geojson_write(
+  d <- supw(supm(geojson_write(
     input = states, lat = "lat", lon = "long",
     geometry = "polygon", group = "group", file = tf11
   )))
@@ -54,7 +56,7 @@ test_that("as.json works with geojson class inputs", {
   ))), "2")
   sp_poly <- SpatialPolygons(list(poly1, poly2), 1:2)
   tf2 <- withr::local_tempfile(fileext = ".geojson")
-  e <- suppressMessages(geojson_write(sp_poly, file = tf2))
+  e <- supm(geojson_write(sp_poly, file = tf2))
   expect_s3_class(e, "geojson_file")
   expect_type(unclass(e), "list")
   expect_s3_class(as.json(e), "json")
@@ -90,7 +92,9 @@ test_that("as.json works with file name inputs", {
   skip_on_cran()
 
   tf3 <- withr::local_tempfile(fileext = ".geojson")
-  ee <- suppressMessages(geojson_write(us_cities[1:2, ], lat = "lat", lon = "long", file = tf3))
+  ee <- supm(
+    geojson_write(us_cities[1:2, ], lat = "lat", lon = "long", file = tf3)
+  )
   expect_s3_class(ee, "geojson_file")
   expect_type(unclass(ee), "list")
   expect_type(ee$path, "character")

--- a/tests/testthat/test-bounds.R
+++ b/tests/testthat/test-bounds.R
@@ -11,7 +11,7 @@ test_that("bounds works with geo_list input", {
 
   # geo_list with data.frame data
   x <- geojson_list(states[1:20, ], lon = "long", lat = "lat")
-  b <- suppressMessages(bounds(x))
+  b <- supm(bounds(x))
   expect_type(b, "double")
   expect_type(b[1], "double")
   expect_equal(length(b), 4)
@@ -25,7 +25,7 @@ test_that("bounds works with list input", {
     list(latitude = 30, longitude = 130, marker = "blue")
   )
   x <- geojson_list(mylist, lon = "longitude", lat = "latitude")
-  c <- suppressMessages(bounds(x))
+  c <- supm(bounds(x))
   expect_type(c, "double")
   expect_type(c[1], "double")
   expect_equal(length(c), 4)

--- a/tests/testthat/test-centroid.R
+++ b/tests/testthat/test-centroid.R
@@ -14,14 +14,14 @@ test_that("centroid works with geo_list input", {
     list(latitude = 30, longitude = 120, marker = "red"),
     list(latitude = 30, longitude = 130, marker = "blue")
   )
-  x <- suppressMessages(geojson_list(mylist))
+  x <- supm(geojson_list(mylist))
   b <- centroid(x)
   expect_type(b, "double")
   expect_type(b[1], "double")
   expect_equal(length(b), 2)
 
   # data.frame input
-  x <- suppressMessages(geojson_list(states[1:20, ]))
+  x <- supm(geojson_list(states[1:20, ]))
   c <- centroid(x)
   expect_type(c, "double")
   expect_type(c[1], "double")

--- a/tests/testthat/test-crs_convert.R
+++ b/tests/testthat/test-crs_convert.R
@@ -7,8 +7,6 @@
 
 # if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
 
-#   suppressPackageStartupMessages(library(sp))
-
 #   sfc <-  st_sfc(st_point(c(0,0)), st_point(c(1,1)))
 #   sf <-  st_sf(a = 1:2, geom = sfc)
 #   sf_4326 <- st_set_crs(sf, 4326)

--- a/tests/testthat/test-crs_convert.R
+++ b/tests/testthat/test-crs_convert.R
@@ -5,12 +5,12 @@
 #   expect_equal(a, b)
 # }
 
-# if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
+# if (requireNamespace("sf", quietly = TRUE)) {
 
-#   sfc <-  st_sfc(st_point(c(0,0)), st_point(c(1,1)))
-#   sf <-  st_sf(a = 1:2, geom = sfc)
-#   sf_4326 <- st_set_crs(sf, 4326)
-#   sf_3005 <- st_transform(sf_4326, 3005)
+#   sfc <-  sf::st_sfc(sf::st_point(c(0,0)), sf::st_point(c(1,1)))
+#   sf <-  sf::st_sf(a = 1:2, geom = sfc)
+#   sf_4326 <- sf::st_set_crs(sf, 4326)
+#   sf_3005 <- sf::st_transform(sf_4326, 3005)
 
 #   pts = cbind(1:5, 1:5)
 #   df = data.frame(a = 1:5)
@@ -68,7 +68,7 @@
 #   test_that("is_wgs84 works with sfc", {
 #     st_crs(sfc) <- 4326
 #     expect_true(is_wgs84(sfc))
-#     sfc_3005 <- st_transform(sfc, 3005)
+#     sfc_3005 <- sf::st_transform(sfc, 3005)
 #     expect_false(suppressWarnings(is_wgs84(sfc_3005)))
 #     expect_warning(is_wgs84(sfc_3005), "WGS84")
 #   })

--- a/tests/testthat/test-crs_convert.R
+++ b/tests/testthat/test-crs_convert.R
@@ -1,5 +1,3 @@
-# sm <- function(x) suppressMessages(x)
-
 # compare_things <- function(a, b) {
 #   a$name <- b$name <- NULL
 #   expect_equal(a, b)
@@ -22,17 +20,17 @@
 #     expect_type(st_crs(convert_wgs84(sf_4326))[["proj4string"]],
 #               "character")
 
-#     expect_type(st_crs(sm(convert_wgs84(sf_3005)))[["proj4string"]],
+#     expect_type(st_crs(supm(convert_wgs84(sf_3005)))[["proj4string"]],
 #                  "character")
 #   })
 
 #   test_that("works with sfc", {
-#     suppressWarnings(st_crs(sfc) <-  4326)
-#     expect_type(st_crs(sm(convert_wgs84(sfc)))[["proj4string"]],
+#     supw(st_crs(sfc) <-  4326)
+#     expect_type(st_crs(supm(convert_wgs84(sfc)))[["proj4string"]],
 #                  "character")
 
-#     suppressWarnings(st_crs(sfc) <- 3005)
-#     expect_type(st_crs(sm(convert_wgs84(sfc)))[["proj4string"]],
+#     supw(st_crs(sfc) <- 3005)
+#     expect_type(st_crs(supm(convert_wgs84(sfc)))[["proj4string"]],
 #                  "character")
 #   })
 
@@ -61,7 +59,7 @@
 
 #   test_that("is_wgs84 works with sf", {
 #     expect_true(is_wgs84(sf_4326))
-#     expect_false(suppressWarnings(is_wgs84(sf_3005)))
+#     expect_false(supw(is_wgs84(sf_3005)))
 #     expect_warning(is_wgs84(sf_3005), "WGS84")
 #   })
 
@@ -69,7 +67,7 @@
 #     st_crs(sfc) <- 4326
 #     expect_true(is_wgs84(sfc))
 #     sfc_3005 <- sf::st_transform(sfc, 3005)
-#     expect_false(suppressWarnings(is_wgs84(sfc_3005)))
+#     expect_false(supw(is_wgs84(sfc_3005)))
 #     expect_warning(is_wgs84(sfc_3005), "WGS84")
 #   })
 
@@ -77,7 +75,7 @@
 #     proj4string(spdf) <- "+init=epsg:4326"
 #     expect_true(is_wgs84(spdf))
 #     spdf_3005 <- supw(as(sf::st_transform(sf::st_as_sf(spdf), 3005), 'Spatial'))
-#     expect_false(suppressWarnings(is_wgs84(spdf_3005)))
+#     expect_false(supw(is_wgs84(spdf_3005)))
 #     expect_warning(is_wgs84(spdf_3005), "WGS84")
 #   })
 

--- a/tests/testthat/test-file_to_geojson.R
+++ b/tests/testthat/test-file_to_geojson.R
@@ -1,8 +1,5 @@
 skip_on_cran()
 
-# kml -------------------------------
-file <- system.file("examples", "norway_maple.kml", package = "geojsonio")
-
 # temp files
 ftog1 <- basename(tempfile())
 ftog2 <- basename(tempfile())
@@ -13,8 +10,11 @@ ftog6 <- basename(tempfile())
 ftog7 <- basename(tempfile())
 
 test_that("file_to_geojson works w/ kml input, web method, output file", {
+  skip_on_cran()
+
   aa <- suppressMessages(file_to_geojson(
-    input = file, method = "web",
+    input = system.file("examples", "norway_maple.kml", package = "geojsonio"),
+    method = "web",
     output = ftog1
   ))
   aa_in <- jsonlite::fromJSON(aa)
@@ -36,7 +36,8 @@ test_that("file_to_geojson works w/ kml input, web method, output memory", {
   skip_on_cran()
 
   aa <- suppressMessages(file_to_geojson(
-    input = file, method = "web",
+    input = system.file("examples", "norway_maple.kml", package = "geojsonio"),
+    method = "web",
     output = ":memory:"
   ))
 
@@ -50,8 +51,11 @@ test_that("file_to_geojson works w/ kml input, web method, output memory", {
 })
 
 test_that("file_to_geojson works w/ kml input, local method, output file", {
+  skip_on_cran()
+
   aa <- suppressMessages(file_to_geojson(
-    input = file, method = "local",
+    input = system.file("examples", "norway_maple.kml", package = "geojsonio"),
+    method = "local",
     output = ftog2
   ))
   aa_in <- jsonlite::fromJSON(aa)
@@ -70,8 +74,11 @@ test_that("file_to_geojson works w/ kml input, local method, output file", {
 })
 
 test_that("file_to_geojson works w/ kml input, local method, output memory", {
+  skip_on_cran()
+
   aa <- suppressMessages(file_to_geojson(
-    input = file, method = "local",
+    input = system.file("examples", "norway_maple.kml", package = "geojsonio"),
+    method = "local",
     output = ":memory:"
   ))
 
@@ -91,7 +98,8 @@ test_that("file_to_geojson works w/ shp zip file input, web method, output file"
   file <- system.file("examples", "bison.zip", package = "geojsonio")
 
   aa <- suppressMessages(file_to_geojson(
-    input = file, method = "web",
+    input = system.file("examples", "norway_maple.kml", package = "geojsonio"),
+    method = "web",
     output = ftog3
   ))
   aa_in <- jsonlite::fromJSON(aa)
@@ -111,6 +119,8 @@ test_that("file_to_geojson works w/ shp zip file input, web method, output file"
 })
 
 test_that("file_to_geojson works w/ shp file input, local method, output file", {
+  skip_on_cran()
+
   file <- system.file("examples", "bison.zip", package = "geojsonio")
   dir <- tempdir()
   unzip(file, exdir = dir)
@@ -142,6 +152,7 @@ kml_url <- "https://raw.githubusercontent.com/ropensci/geojsonio/master/inst/exa
 
 test_that("file_to_geojson works w/ url kml input, web method, local output", {
   skip_on_cran()
+
   aa <- suppressMessages(file_to_geojson(input = kml_url, method = "web", output = ftog5))
 
   aa_in <- jsonlite::fromJSON(aa)
@@ -162,6 +173,7 @@ test_that("file_to_geojson works w/ url kml input, web method, local output", {
 
 test_that("file_to_geojson works w/ url kml input, local method, local output", {
   skip_on_cran()
+
   aa <- suppressMessages(file_to_geojson(kml_url, method = "local", output = ftog6))
 
   aa_in <- jsonlite::fromJSON(aa)
@@ -182,6 +194,7 @@ test_that("file_to_geojson works w/ url kml input, local method, local output", 
 
 test_that("file_to_geojson works w/ url kml input, web method, memory output", {
   skip_on_cran()
+
   aa <- suppressMessages(file_to_geojson(kml_url, method = "web", output = ":memory:"))
 
   expect_type(aa, "list")
@@ -194,6 +207,7 @@ test_that("file_to_geojson works w/ url kml input, web method, memory output", {
 
 test_that("file_to_geojson works w/ url kml input, local method, memory output", {
   skip_on_cran()
+
   aa <- suppressMessages(file_to_geojson(kml_url, method = "local", output = ":memory:"))
 
   expect_type(aa, "list")
@@ -247,6 +261,8 @@ test_that("file_to_geojson works w/ url shp zip file input, web method, memory o
 })
 
 test_that("file_to_geojson fails well", {
+  skip_on_cran()
+
   file <- system.file("examples", "norway_maple.kml", package = "geojsonio")
 
   expect_error(file_to_geojson(), "argument \"input\" is missing")

--- a/tests/testthat/test-file_to_geojson.R
+++ b/tests/testthat/test-file_to_geojson.R
@@ -1,35 +1,23 @@
-skip_on_cran()
-
-# temp files
-ftog1 <- basename(tempfile())
-ftog2 <- basename(tempfile())
-ftog3 <- basename(tempfile())
-ftog4 <- basename(tempfile())
-ftog5 <- basename(tempfile())
-ftog6 <- basename(tempfile())
-ftog7 <- basename(tempfile())
-
 test_that("file_to_geojson works w/ kml input, web method, output file", {
   skip_on_cran()
+
+  file <- withr::local_tempfile(fileext = ".geojson")
 
   aa <- suppressMessages(file_to_geojson(
     input = system.file("examples", "norway_maple.kml", package = "geojsonio"),
     method = "web",
-    output = ftog1
+    output = file
   ))
   aa_in <- jsonlite::fromJSON(aa)
 
   expect_type(aa, "character")
   expect_true(file.exists(aa))
-  expect_match(aa, paste0(ftog1, ".geojson"))
+  expect_match(aa, file)
 
   expect_type(aa_in, "list")
   expect_equal(aa_in$type, "FeatureCollection")
   expect_type(aa_in$crs, "list")
   expect_s3_class(aa_in$features, "data.frame")
-
-  # cleanup
-  unlink(paste0(ftog1, ".geojson"))
 })
 
 test_that("file_to_geojson works w/ kml input, web method, output memory", {
@@ -53,24 +41,23 @@ test_that("file_to_geojson works w/ kml input, web method, output memory", {
 test_that("file_to_geojson works w/ kml input, local method, output file", {
   skip_on_cran()
 
+  file <- withr::local_tempfile(fileext = ".geojson")
+
   aa <- suppressMessages(file_to_geojson(
     input = system.file("examples", "norway_maple.kml", package = "geojsonio"),
     method = "local",
-    output = ftog2
+    output = file
   ))
   aa_in <- jsonlite::fromJSON(aa)
 
   expect_type(aa, "character")
   expect_true(file.exists(aa))
-  expect_match(aa, ftog2)
+  expect_match(aa, file)
 
   expect_equal(aa_in$type, "FeatureCollection")
   expect_s3_class(aa_in$features, "data.frame")
 
   expect_s3_class(as.json(aa_in), "json")
-
-  # cleanup
-  unlink(paste0(ftog2, ".geojson"))
 })
 
 test_that("file_to_geojson works w/ kml input, local method, output memory", {
@@ -96,54 +83,50 @@ test_that("file_to_geojson works w/ shp zip file input, web method, output file"
   skip_on_cran()
 
   file <- system.file("examples", "bison.zip", package = "geojsonio")
+  output_file <- withr::local_tempfile(fileext = ".geojson")
 
   aa <- suppressMessages(file_to_geojson(
     input = system.file("examples", "norway_maple.kml", package = "geojsonio"),
     method = "web",
-    output = ftog3
+    output = output_file
   ))
   aa_in <- jsonlite::fromJSON(aa)
 
   expect_type(aa, "character")
   expect_true(file.exists(aa))
-  expect_match(aa, paste0(ftog3, ".geojson"))
+  expect_match(aa, output_file)
 
   expect_type(aa_in, "list")
   expect_equal(aa_in$type, "FeatureCollection")
   expect_type(aa_in$crs, "list")
 
   expect_s3_class(as.json(aa_in), "json")
-
-  # cleanup
-  unlink(paste0(ftog3, ".geojson"))
 })
 
 test_that("file_to_geojson works w/ shp file input, local method, output file", {
   skip_on_cran()
 
   file <- system.file("examples", "bison.zip", package = "geojsonio")
-  dir <- tempdir()
+  output_file <- withr::local_tempfile(fileext = ".geojson")
+  dir <- withr::local_tempdir()
   unzip(file, exdir = dir)
   shpfile <- file.path(dir, "bison-Bison_bison-20130704-120856.shp")
 
   aa <- suppressMessages(file_to_geojson(
     input = shpfile, method = "local",
-    output = ftog4
+    output = output_file
   ))
   aa_in <- jsonlite::fromJSON(aa)
 
   expect_type(aa, "character")
   expect_true(file.exists(aa))
-  expect_match(aa, ftog4)
+  expect_match(aa, output_file)
 
   expect_type(aa_in, "list")
   expect_equal(aa_in$type, "FeatureCollection")
   expect_s3_class(aa_in$features, "data.frame")
 
   expect_s3_class(as.json(aa_in), "json")
-
-  # cleanup
-  unlink(paste0(ftog4, ".geojson"))
 })
 
 ## Testing with url
@@ -153,43 +136,40 @@ kml_url <- "https://raw.githubusercontent.com/ropensci/geojsonio/master/inst/exa
 test_that("file_to_geojson works w/ url kml input, web method, local output", {
   skip_on_cran()
 
-  aa <- suppressMessages(file_to_geojson(input = kml_url, method = "web", output = ftog5))
+  file <- withr::local_tempfile(fileext = ".geojson")
+
+  aa <- suppressMessages(file_to_geojson(input = kml_url, method = "web", output = file))
 
   aa_in <- jsonlite::fromJSON(aa)
 
   expect_type(aa, "character")
   expect_true(file.exists(aa))
-  expect_match(aa, paste0(ftog5, ".geojson"))
+  expect_match(aa, file)
 
   expect_type(aa_in, "list")
   expect_equal(aa_in$type, "FeatureCollection")
   expect_s3_class(aa_in$features, "data.frame")
 
   expect_s3_class(as.json(aa_in), "json")
-
-  # cleanup
-  unlink(paste0(ftog5, ".geojson"))
 })
 
 test_that("file_to_geojson works w/ url kml input, local method, local output", {
   skip_on_cran()
 
-  aa <- suppressMessages(file_to_geojson(kml_url, method = "local", output = ftog6))
+  file <- withr::local_tempfile(fileext = ".geojson")
+  aa <- suppressMessages(file_to_geojson(kml_url, method = "local", output = file))
 
   aa_in <- jsonlite::fromJSON(aa)
 
   expect_type(aa, "character")
   expect_true(file.exists(aa))
-  expect_match(aa, ftog6)
+  expect_match(aa, file)
 
   expect_type(aa_in, "list")
   expect_equal(aa_in$type, "FeatureCollection")
   expect_s3_class(aa_in$features, "data.frame")
 
   expect_s3_class(as.json(aa_in), "json")
-
-  # cleanup
-  unlink(paste0(ftog6, ".geojson"))
 })
 
 test_that("file_to_geojson works w/ url kml input, web method, memory output", {
@@ -224,24 +204,23 @@ shp_url <- "https://raw.githubusercontent.com/ropensci/geojsonio/master/inst/exa
 test_that("file_to_geojson works w/ url shp zip file input, web method, output file", {
   skip_on_cran()
 
+  file <- withr::local_tempfile(fileext = ".geojson")
+
   aa <- suppressMessages(file_to_geojson(
     input = shp_url, method = "web",
-    output = ftog7
+    output = file
   ))
   aa_in <- jsonlite::fromJSON(aa)
 
   expect_type(aa, "character")
   expect_true(file.exists(aa))
-  expect_match(aa, paste0(ftog7, ".geojson"))
+  expect_match(aa, file)
 
   expect_type(aa_in, "list")
   expect_equal(aa_in$type, "FeatureCollection")
   expect_type(aa_in$crs, "list")
 
   expect_s3_class(as.json(aa_in), "json")
-
-  # cleanup
-  unlink(paste0(ftog7, ".geojson"))
 })
 
 test_that("file_to_geojson works w/ url shp zip file input, web method, memory output", {
@@ -269,6 +248,3 @@ test_that("file_to_geojson fails well", {
   expect_error(file_to_geojson(file, method = "adfadf"), "'arg' should be one of")
   expect_error(file_to_geojson(file, parse = "foobar"), "parse must be logical")
 })
-
-# cleanup any files that weren't cleaned up with above cleanups
-unlink(list.files(pattern = "file[0-9]+", full.names = TRUE))

--- a/tests/testthat/test-file_to_geojson.R
+++ b/tests/testthat/test-file_to_geojson.R
@@ -3,7 +3,7 @@ test_that("file_to_geojson works w/ kml input, web method, output file", {
 
   file <- withr::local_tempfile(fileext = ".geojson")
 
-  aa <- suppressMessages(file_to_geojson(
+  aa <- supm(file_to_geojson(
     input = system.file("examples", "norway_maple.kml", package = "geojsonio"),
     method = "web",
     output = file
@@ -23,7 +23,7 @@ test_that("file_to_geojson works w/ kml input, web method, output file", {
 test_that("file_to_geojson works w/ kml input, web method, output memory", {
   skip_on_cran()
 
-  aa <- suppressMessages(file_to_geojson(
+  aa <- supm(file_to_geojson(
     input = system.file("examples", "norway_maple.kml", package = "geojsonio"),
     method = "web",
     output = ":memory:"
@@ -43,7 +43,7 @@ test_that("file_to_geojson works w/ kml input, local method, output file", {
 
   file <- withr::local_tempfile(fileext = ".geojson")
 
-  aa <- suppressMessages(file_to_geojson(
+  aa <- supm(file_to_geojson(
     input = system.file("examples", "norway_maple.kml", package = "geojsonio"),
     method = "local",
     output = file
@@ -63,7 +63,7 @@ test_that("file_to_geojson works w/ kml input, local method, output file", {
 test_that("file_to_geojson works w/ kml input, local method, output memory", {
   skip_on_cran()
 
-  aa <- suppressMessages(file_to_geojson(
+  aa <- supm(file_to_geojson(
     input = system.file("examples", "norway_maple.kml", package = "geojsonio"),
     method = "local",
     output = ":memory:"
@@ -85,7 +85,7 @@ test_that("file_to_geojson works w/ shp zip file input, web method, output file"
   file <- system.file("examples", "bison.zip", package = "geojsonio")
   output_file <- withr::local_tempfile(fileext = ".geojson")
 
-  aa <- suppressMessages(file_to_geojson(
+  aa <- supm(file_to_geojson(
     input = system.file("examples", "norway_maple.kml", package = "geojsonio"),
     method = "web",
     output = output_file
@@ -112,7 +112,7 @@ test_that("file_to_geojson works w/ shp file input, local method, output file", 
   unzip(file, exdir = dir)
   shpfile <- file.path(dir, "bison-Bison_bison-20130704-120856.shp")
 
-  aa <- suppressMessages(file_to_geojson(
+  aa <- supm(file_to_geojson(
     input = shpfile, method = "local",
     output = output_file
   ))
@@ -138,7 +138,7 @@ test_that("file_to_geojson works w/ url kml input, web method, local output", {
 
   file <- withr::local_tempfile(fileext = ".geojson")
 
-  aa <- suppressMessages(file_to_geojson(input = kml_url, method = "web", output = file))
+  aa <- supm(file_to_geojson(input = kml_url, method = "web", output = file))
 
   aa_in <- jsonlite::fromJSON(aa)
 
@@ -157,7 +157,7 @@ test_that("file_to_geojson works w/ url kml input, local method, local output", 
   skip_on_cran()
 
   file <- withr::local_tempfile(fileext = ".geojson")
-  aa <- suppressMessages(file_to_geojson(kml_url, method = "local", output = file))
+  aa <- supm(file_to_geojson(kml_url, method = "local", output = file))
 
   aa_in <- jsonlite::fromJSON(aa)
 
@@ -175,7 +175,7 @@ test_that("file_to_geojson works w/ url kml input, local method, local output", 
 test_that("file_to_geojson works w/ url kml input, web method, memory output", {
   skip_on_cran()
 
-  aa <- suppressMessages(file_to_geojson(kml_url, method = "web", output = ":memory:"))
+  aa <- supm(file_to_geojson(kml_url, method = "web", output = ":memory:"))
 
   expect_type(aa, "list")
   expect_equal(aa$type, "FeatureCollection")
@@ -188,7 +188,7 @@ test_that("file_to_geojson works w/ url kml input, web method, memory output", {
 test_that("file_to_geojson works w/ url kml input, local method, memory output", {
   skip_on_cran()
 
-  aa <- suppressMessages(file_to_geojson(kml_url, method = "local", output = ":memory:"))
+  aa <- supm(file_to_geojson(kml_url, method = "local", output = ":memory:"))
 
   expect_type(aa, "list")
   expect_equal(aa$type, "FeatureCollection")
@@ -206,7 +206,7 @@ test_that("file_to_geojson works w/ url shp zip file input, web method, output f
 
   file <- withr::local_tempfile(fileext = ".geojson")
 
-  aa <- suppressMessages(file_to_geojson(
+  aa <- supm(file_to_geojson(
     input = shp_url, method = "web",
     output = file
   ))
@@ -226,7 +226,7 @@ test_that("file_to_geojson works w/ url shp zip file input, web method, output f
 test_that("file_to_geojson works w/ url shp zip file input, web method, memory output", {
   skip_on_cran()
 
-  aa <- suppressMessages(file_to_geojson(
+  aa <- supm(file_to_geojson(
     input = shp_url, method = "web",
     output = ":memory:"
   ))

--- a/tests/testthat/test-file_to_geojson.R
+++ b/tests/testthat/test-file_to_geojson.R
@@ -4,7 +4,7 @@ test_that("file_to_geojson works w/ kml input, web method, output file", {
   file <- withr::local_tempfile(fileext = ".geojson")
 
   aa <- supm(file_to_geojson(
-    input = system.file("examples", "norway_maple.kml", package = "geojsonio"),
+    input = example_sys_file("norway_maple.kml"),
     method = "web",
     output = file
   ))
@@ -24,7 +24,7 @@ test_that("file_to_geojson works w/ kml input, web method, output memory", {
   skip_on_cran()
 
   aa <- supm(file_to_geojson(
-    input = system.file("examples", "norway_maple.kml", package = "geojsonio"),
+    input = example_sys_file("norway_maple.kml"),
     method = "web",
     output = ":memory:"
   ))
@@ -44,7 +44,7 @@ test_that("file_to_geojson works w/ kml input, local method, output file", {
   file <- withr::local_tempfile(fileext = ".geojson")
 
   aa <- supm(file_to_geojson(
-    input = system.file("examples", "norway_maple.kml", package = "geojsonio"),
+    input = example_sys_file("norway_maple.kml"),
     method = "local",
     output = file
   ))
@@ -64,7 +64,7 @@ test_that("file_to_geojson works w/ kml input, local method, output memory", {
   skip_on_cran()
 
   aa <- supm(file_to_geojson(
-    input = system.file("examples", "norway_maple.kml", package = "geojsonio"),
+    input = example_sys_file("norway_maple.kml"),
     method = "local",
     output = ":memory:"
   ))
@@ -82,11 +82,11 @@ test_that("file_to_geojson works w/ kml input, local method, output memory", {
 test_that("file_to_geojson works w/ shp zip file input, web method, output file", {
   skip_on_cran()
 
-  file <- system.file("examples", "bison.zip", package = "geojsonio")
+  file <- example_sys_file("bison.zip")
   output_file <- withr::local_tempfile(fileext = ".geojson")
 
   aa <- supm(file_to_geojson(
-    input = system.file("examples", "norway_maple.kml", package = "geojsonio"),
+    input = example_sys_file("norway_maple.kml"),
     method = "web",
     output = output_file
   ))
@@ -106,7 +106,7 @@ test_that("file_to_geojson works w/ shp zip file input, web method, output file"
 test_that("file_to_geojson works w/ shp file input, local method, output file", {
   skip_on_cran()
 
-  file <- system.file("examples", "bison.zip", package = "geojsonio")
+  file <- example_sys_file("bison.zip")
   output_file <- withr::local_tempfile(fileext = ".geojson")
   dir <- withr::local_tempdir()
   unzip(file, exdir = dir)
@@ -242,7 +242,7 @@ test_that("file_to_geojson works w/ url shp zip file input, web method, memory o
 test_that("file_to_geojson fails well", {
   skip_on_cran()
 
-  file <- system.file("examples", "norway_maple.kml", package = "geojsonio")
+  file <- example_sys_file("norway_maple.kml")
 
   expect_error(file_to_geojson(), "argument \"input\" is missing")
   expect_error(file_to_geojson(file, method = "adfadf"), "'arg' should be one of")

--- a/tests/testthat/test-geo_topo.R
+++ b/tests/testthat/test-geo_topo.R
@@ -58,10 +58,6 @@ test_that("topo2geo works", {
   expect_s3_class(w, "geofeaturecollection")
 })
 
-
-
-
-
 test_that("quantization > 0 in geo2topo", {
   skip_on_cran()
 

--- a/tests/testthat/test-geojson_json.R
+++ b/tests/testthat/test-geojson_json.R
@@ -133,10 +133,10 @@ test_that("skipping geoclass in geojson_json works with type = skip", {
   expect_null(attr(geojson_json(x, type = "skip"), "type"))
 })
 
-def_digits <- getOption("digits")
-options(digits = 15)
 test_that("geojson_json precision", {
   skip_on_cran()
+
+  withr::local_options(digits = 15)
 
   # numeric
   x <- geojson_json(c(-99.123456789, 32.12345678), precision = 10)
@@ -195,6 +195,3 @@ test_that("geojson_json precision", {
     c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 3, 0, 0, 3, 1, 0, 0, 1)
   )
 })
-
-# reset digits to default value
-options(digits = def_digits)

--- a/tests/testthat/test-geojson_json.R
+++ b/tests/testthat/test-geojson_json.R
@@ -161,8 +161,12 @@ test_that("geojson_json precision", {
   a <- geojson_list(df, precision = 5, lat = "lat", lon = "lon")
   x <- geojson_json(a, precision = 5)
   expect_equal(num_digits(x), c(0, 3, 5, 2))
+})
 
-  # sp classes: SpatialPolygons
+test_that("geojson_json precision for sp classes", {
+  skip_on_cran()
+  withr::local_options(digits = 15)
+  
   poly1 <- Polygons(list(Polygon(cbind(
     c(-100.1, -90.12, -85.123, -100.1234),
     c(40, 50, 45, 40)
@@ -180,8 +184,14 @@ test_that("geojson_json precision", {
     num_digits(geojson_json(sp_poly, precision = 2)),
     c(1, 2, 2, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
   )
+})
 
-  # sf classes
+test_that("geojson_json precision for sf classes", {
+  skip_on_cran()
+  skip_if_not_installed("sf")
+
+  withr::local_options(digits = 15)
+
   p1 <- rbind(c(0, 0), c(1, 0), c(3, 2), c(2, 4), c(1, 4.1234567), c(0, 0))
   p2 <- rbind(c(5.123, 5.1), c(5, 6), c(4, 5), c(5.123, 5.1))
   poly_sfc <- sf::st_sfc(sf::st_polygon(list(p1)), sf::st_polygon(list(p2)))
@@ -189,7 +199,6 @@ test_that("geojson_json precision", {
     num_digits(geojson_json(poly_sfc)),
     c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 3, 0, 0, 3, 1, 0, 0, 1)
   )
-  # FIXME: not working yet
   expect_equal(
     num_digits(geojson_json(poly_sfc, precision = 2)),
     c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 3, 0, 0, 3, 1, 0, 0, 1)

--- a/tests/testthat/test-geojson_json.R
+++ b/tests/testthat/test-geojson_json.R
@@ -163,7 +163,6 @@ test_that("geojson_json precision", {
   expect_equal(num_digits(x), c(0, 3, 5, 2))
 
   # sp classes: SpatialPolygons
-  library("sp")
   poly1 <- Polygons(list(Polygon(cbind(
     c(-100.1, -90.12, -85.123, -100.1234),
     c(40, 50, 45, 40)
@@ -183,7 +182,6 @@ test_that("geojson_json precision", {
   )
 
   # sf classes
-  library("sf")
   p1 <- rbind(c(0, 0), c(1, 0), c(3, 2), c(2, 4), c(1, 4.1234567), c(0, 0))
   p2 <- rbind(c(5.123, 5.1), c(5, 6), c(4, 5), c(5.123, 5.1))
   poly_sfc <- st_sfc(st_polygon(list(p1)), st_polygon(list(p2)))

--- a/tests/testthat/test-geojson_json.R
+++ b/tests/testthat/test-geojson_json.R
@@ -184,7 +184,7 @@ test_that("geojson_json precision", {
   # sf classes
   p1 <- rbind(c(0, 0), c(1, 0), c(3, 2), c(2, 4), c(1, 4.1234567), c(0, 0))
   p2 <- rbind(c(5.123, 5.1), c(5, 6), c(4, 5), c(5.123, 5.1))
-  poly_sfc <- st_sfc(st_polygon(list(p1)), st_polygon(list(p2)))
+  poly_sfc <- sf::st_sfc(sf::st_polygon(list(p1)), sf::st_polygon(list(p2)))
   expect_equal(
     num_digits(geojson_json(poly_sfc)),
     c(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 3, 0, 0, 3, 1, 0, 0, 1)

--- a/tests/testthat/test-geojson_read.R
+++ b/tests/testthat/test-geojson_read.R
@@ -1,6 +1,3 @@
-features_names <- sort(c("type", "properties", "geometry"))
-top_names <- sort(c("type", "features"))
-
 test_that("geojson_read works with file inputs", {
   skip_on_cran()
 
@@ -11,13 +8,14 @@ test_that("geojson_read works with file inputs", {
   expect_equal(aa$type, "FeatureCollection")
   expect_type(aa$features, "list")
   expect_equal(aa$features[[1]]$type, "Feature")
-  expect_equal(sort(names(aa$features[[1]])), features_names)
-  expect_true(all(top_names %in% names(aa)))
+  expect_setequal(
+    names(aa$features[[1]]),
+    c("type", "properties", "geometry")
+  )
+  expect_true(all(c("type", "features") %in% names(aa)))
 })
 
 test_that("geojson_read works with url inputs", {
-  skip_on_cran()
-
   skip_on_cran()
 
   url <- "https://raw.githubusercontent.com/glynnbird/usstatesgeojson/master/california.geojson"
@@ -27,7 +25,10 @@ test_that("geojson_read works with url inputs", {
   expect_equal(aa$type, "FeatureCollection")
   expect_type(aa$features, "list")
   expect_equal(aa$features[[1]]$type, "Feature")
-  expect_equal(sort(names(aa$features[[1]])), features_names)
+  expect_setequal(
+    names(aa$features[[1]]),
+    c("type", "properties", "geometry")
+  )
 })
 
 test_that("geojson_read works with as.location inputs", {
@@ -40,8 +41,11 @@ test_that("geojson_read works with as.location inputs", {
   expect_equal(aa$type, "FeatureCollection")
   expect_type(aa$features, "list")
   expect_equal(aa$features[[1]]$type, "Feature")
-  expect_equal(sort(names(aa$features[[1]])), features_names)
-  expect_true(all(top_names %in% names(aa)))
+  expect_setequal(
+    names(aa$features[[1]]),
+    c("type", "properties", "geometry")
+  )
+  expect_true(all(c("type", "features") %in% names(aa)))
 })
 
 test_that("geojson_read works outputing spatial class object", {

--- a/tests/testthat/test-geojson_read.R
+++ b/tests/testthat/test-geojson_read.R
@@ -1,7 +1,7 @@
 test_that("geojson_read works with file inputs", {
   skip_on_cran()
 
-  file <- system.file("examples", "california.geojson", package = "geojsonio")
+  file <- example_sys_file("california.geojson")
   aa <- geojson_read(file)
 
   expect_type(aa, "list")
@@ -34,7 +34,7 @@ test_that("geojson_read works with url inputs", {
 test_that("geojson_read works with as.location inputs", {
   skip_on_cran()
 
-  file <- system.file("examples", "california.geojson", package = "geojsonio")
+  file <- example_sys_file("california.geojson")
   aa <- geojson_read(as.location(file))
 
   expect_type(aa, "list")
@@ -51,7 +51,7 @@ test_that("geojson_read works with as.location inputs", {
 test_that("geojson_read works outputing spatial class object", {
   skip_on_cran()
 
-  file <- system.file("examples", "norway_maple.kml", package = "geojsonio")
+  file <- example_sys_file("norway_maple.kml")
   aa <- geojson_read(as.location(file), what = "sp")
 
   expect_s4_class(aa, "SpatialPointsDataFrame")

--- a/tests/testthat/test-geojson_sf.R
+++ b/tests/testthat/test-geojson_sf.R
@@ -11,7 +11,7 @@ test_that("geojson_sf works with geo_list inputs", {
     list(latitude = 30, longitude = 120, marker = "red"),
     list(latitude = 30, longitude = 130, marker = "blue")
   )
-  b <- geojson_sf(suppressMessages(geojson_list(mylist)))
+  b <- geojson_sf(supm(geojson_list(mylist)))
   expect_s3_class(b, "sf")
 
   # from a list of numeric vectors to a polygon
@@ -41,7 +41,7 @@ test_that("geojson_sf works with json inputs", {
     list(latitude = 30, longitude = 120, marker = "red"),
     list(latitude = 30, longitude = 130, marker = "blue")
   )
-  b <- geojson_sf(suppressMessages(geojson_json(mylist)))
+  b <- geojson_sf(supm(geojson_json(mylist)))
   expect_s3_class(b, "sf")
 
   # from a polygon

--- a/tests/testthat/test-geojson_sf.R
+++ b/tests/testthat/test-geojson_sf.R
@@ -45,22 +45,17 @@ test_that("geojson_sf works with json inputs", {
   expect_s3_class(b, "sf")
 
   # from a polygon
-  poly <- structure('{"type":"FeatureCollection","features":[{
-"type": "Feature",
-"properties": {},
-"geometry": {
-"type": "Polygon",
-"coordinates": [
-[
-[53, -42],
-[57, -42],
-[57, -47],
-[53, -47],
-[53, -42]
-]
-]
-}}]
-}', class = c("json", "geo_json"))
+  poly <- structure('{
+    "type":"FeatureCollection",
+    "features":[{
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[53, -42],[57, -42],[57, -47],[53, -47],[53, -42]]]
+      }
+    }]
+  }', class = c("json", "geo_json"))
   d <- geojson_sf(poly)
   expect_s3_class(d, "sf")
 })

--- a/tests/testthat/test-geojson_sp.R
+++ b/tests/testthat/test-geojson_sp.R
@@ -11,7 +11,7 @@ test_that("geojson_sp works with geo_list inputs", {
     list(latitude = 30, longitude = 120, marker = "red"),
     list(latitude = 30, longitude = 130, marker = "blue")
   )
-  b <- geojson_sp(suppressMessages(geojson_list(mylist)))
+  b <- geojson_sp(supm(geojson_list(mylist)))
   expect_s4_class(b, "SpatialPointsDataFrame")
 
   # from a list of numeric vectors to a polygon
@@ -41,7 +41,7 @@ test_that("geojson_sp works with json inputs", {
     list(latitude = 30, longitude = 120, marker = "red"),
     list(latitude = 30, longitude = 130, marker = "blue")
   )
-  b <- geojson_sp(suppressMessages(geojson_json(mylist)))
+  b <- geojson_sp(supm(geojson_json(mylist)))
   expect_s4_class(b, "SpatialPointsDataFrame")
 
   # from a polygon

--- a/tests/testthat/test-geojson_write.R
+++ b/tests/testthat/test-geojson_write.R
@@ -52,7 +52,6 @@ test_that("precision argument works with sp objects in geojson_write", {
   skip_on_travis()
   skip_on_cran()
 
-  library("sp")
   poly1 <- Polygons(list(Polygon(cbind(
     c(-100.111, -90.111, -85.111, -100.111),
     c(40.111, 50.111, 45.111, 40.111)
@@ -106,8 +105,6 @@ test_that("geojson_write detects inproper polygons passed as lists inputs", {
 
 test_that("geojson_write unclasses columns with special classes so writeOGR works", {
   skip_on_cran()
-  library("sp")
-  library("sf")
 
   poly1 <- Polygons(list(Polygon(cbind(
     c(-100, -90, -85, -100),

--- a/tests/testthat/test-geojson_write.R
+++ b/tests/testthat/test-geojson_write.R
@@ -10,13 +10,13 @@ test_that("precision argument works with polygons in geojson_write", {
     c(-114.345703125, 39.436192999314095)
   )
   gwf1 <- withr::local_tempfile(fileext = ".geojson")
-  a <- supw(suppressMessages(geojson_write(poly, geometry = "polygon", file = gwf1)))
+  a <- supw(supm(geojson_write(poly, geometry = "polygon", file = gwf1)))
   expect_s3_class(a, "geojson_file")
   a_txt <- gsub("\\s+", " ", paste0(readLines(gwf1), collapse = ""))
   expect_equal(as.numeric(jqr::jq(a_txt, ".features[] | length")), 3)
 
   gwf2 <- withr::local_tempfile(fileext = ".geojson")
-  b <- supw(suppressMessages(geojson_write(poly, geometry = "polygon", precision = 2, file = gwf2)))
+  b <- supw(supm(geojson_write(poly, geometry = "polygon", precision = 2, file = gwf2)))
   expect_s3_class(b, "geojson_file")
   b_txt <- gsub("\\s+", " ", paste0(readLines(gwf2), collapse = ""))
   expect_equal(
@@ -30,7 +30,7 @@ test_that("precision argument works with points in geojson_write", {
   skip_on_cran()
 
   gwf3 <- withr::local_tempfile(fileext = ".geojson")
-  cc <- suppressMessages(geojson_write(us_cities[1:2, ], lat = "lat", lon = "long", precision = 2, file = gwf3))
+  cc <- supm(geojson_write(us_cities[1:2, ], lat = "lat", lon = "long", precision = 2, file = gwf3))
   expect_s3_class(cc, "geojson_file")
   cc_txt <- gsub("\\s+", " ", paste0(readLines(gwf3), collapse = ""))
   expect_equal(
@@ -39,7 +39,7 @@ test_that("precision argument works with points in geojson_write", {
   )
 
   gwf4 <- withr::local_tempfile(fileext = ".geojson")
-  d <- suppressMessages(geojson_write(us_cities[1:2, ], lat = "lat", lon = "long", precision = 1, file = gwf4))
+  d <- supm(geojson_write(us_cities[1:2, ], lat = "lat", lon = "long", precision = 1, file = gwf4))
   expect_s3_class(d, "geojson_file")
   d_txt <- gsub("\\s+", " ", paste0(readLines(gwf4), collapse = ""))
   expect_equal(
@@ -63,7 +63,7 @@ test_that("precision argument works with sp objects in geojson_write", {
   sp_poly <- SpatialPolygons(list(poly1, poly2), 1:2)
 
   gwf5 <- withr::local_tempfile(fileext = ".geojson")
-  e <- suppressMessages(geojson_write(sp_poly, file = gwf5))
+  e <- supm(geojson_write(sp_poly, file = gwf5))
   expect_s3_class(e, "geojson_file")
   e_txt <- gsub("\\s+", " ", paste0(readLines(gwf5), collapse = ""))
   expect_equal(
@@ -72,7 +72,7 @@ test_that("precision argument works with sp objects in geojson_write", {
   )
 
   gwf6 <- withr::local_tempfile(fileext = ".geojson")
-  f <- suppressMessages(geojson_write(sp_poly, precision = 2, file = gwf6))
+  f <- supm(geojson_write(sp_poly, precision = 2, file = gwf6))
   expect_s3_class(f, "geojson_file")
   f_txt <- gsub("\\s+", " ", paste0(readLines(gwf6), collapse = ""))
   expect_equal(
@@ -89,7 +89,7 @@ test_that("geojson_write detects inproper polygons passed as lists inputs", {
 
   # fine
   gwf7 <- withr::local_tempfile(fileext = ".geojson")
-  fine <- supw(suppressMessages(geojson_write(good, geometry = "polygon", file = gwf7)))
+  fine <- supw(supm(geojson_write(good, geometry = "polygon", file = gwf7)))
   expect_s3_class(fine, "geojson_file")
   expect_type(fine[[1]], "character")
 
@@ -101,7 +101,7 @@ test_that("geojson_write detects inproper polygons passed as lists inputs", {
 
   # doesn't matter if geometry != polygon
   expect_s3_class(
-    suppressMessages(geojson_write(
+    supm(geojson_write(
       bad,
       file = withr::local_tempfile(fileext = ".geojson")
     )),
@@ -124,7 +124,10 @@ test_that("geojson_write unclasses columns with special classes so writeOGR work
     )
   )
   gwf8 <- withr::local_tempfile(fileext = ".geojson")
-  expect_s3_class(geojson_write(spdf, file = gwf8), "geojson_file")
+  expect_s3_class(
+    supm(geojson_write(spdf, file = gwf8)), 
+    "geojson_file"
+  )
   if (requireNamespace("sf", quietly = TRUE)) {
     spdf2 <- as(sf::st_read(gwf8, quiet = TRUE, stringsAsFactors = FALSE), "Spatial")
     expect_type(spdf2@data$a, "double")
@@ -156,11 +159,11 @@ test_that("geojson_write passes toJSON args", {
 
     gwf9 <- withr::local_tempfile(fileext = ".geojson")
 
-    geojson_write(pt_sf, file = gwf9)
+    supm(geojson_write(pt_sf, file = gwf9))
     expect_equal(readLines(gwf9, warn = FALSE), expected_na_no_pretty)
 
     gwf10 <- withr::local_tempfile(fileext = ".geojson")
-    geojson_write(pt_sf, file = gwf10, na = "null", pretty = TRUE)
+    supm(geojson_write(pt_sf, file = gwf10, na = "null", pretty = TRUE))
     expect_equal(readLines(gwf10, warn = FALSE), expected_null_pretty)
   }
 
@@ -191,10 +194,10 @@ test_that("geojson_write passes toJSON args", {
 
   gwf11 <- withr::local_tempfile(fileext = ".geojson")
 
-  geojson_write(pt_geo_list, file = gwf11)
+  supm(geojson_write(pt_geo_list, file = gwf11))
   expect_equal(readLines(gwf11, warn = FALSE), expected_na_no_pretty)
 
   gwf12 <- withr::local_tempfile(fileext = ".geojson")
-  geojson_write(pt_geo_list, file = gwf12, na = "null", pretty = TRUE)
+  supm(geojson_write(pt_geo_list, file = gwf12, na = "null", pretty = TRUE))
   expect_equal(readLines(gwf12, warn = FALSE), expected_null_pretty)
 })

--- a/tests/testthat/test-geojson_write.R
+++ b/tests/testthat/test-geojson_write.R
@@ -100,7 +100,13 @@ test_that("geojson_write detects inproper polygons passed as lists inputs", {
   )
 
   # doesn't matter if geometry != polygon
-  expect_s3_class(suppressMessages(geojson_write(bad)), "geojson_file")
+  expect_s3_class(
+    suppressMessages(geojson_write(
+      bad,
+      file = withr::local_tempfile(fileext = ".geojson")
+    )),
+    "geojson_file"
+  )
 })
 
 test_that("geojson_write unclasses columns with special classes so writeOGR works", {

--- a/tests/testthat/test-geojson_write.R
+++ b/tests/testthat/test-geojson_write.R
@@ -9,13 +9,13 @@ test_that("precision argument works with polygons in geojson_write", {
     c(-106.61132812499999, 39.436192999314095),
     c(-114.345703125, 39.436192999314095)
   )
-  gwf1 <- tempfile(fileext = ".geojson")
+  gwf1 <- withr::local_tempfile(fileext = ".geojson")
   a <- supw(suppressMessages(geojson_write(poly, geometry = "polygon", file = gwf1)))
   expect_s3_class(a, "geojson_file")
   a_txt <- gsub("\\s+", " ", paste0(readLines(gwf1), collapse = ""))
   expect_equal(as.numeric(jqr::jq(a_txt, ".features[] | length")), 3)
 
-  gwf2 <- tempfile(fileext = ".geojson")
+  gwf2 <- withr::local_tempfile(fileext = ".geojson")
   b <- supw(suppressMessages(geojson_write(poly, geometry = "polygon", precision = 2, file = gwf2)))
   expect_s3_class(b, "geojson_file")
   b_txt <- gsub("\\s+", " ", paste0(readLines(gwf2), collapse = ""))
@@ -29,7 +29,7 @@ test_that("precision argument works with points in geojson_write", {
   skip_on_travis()
   skip_on_cran()
 
-  gwf3 <- tempfile(fileext = ".geojson")
+  gwf3 <- withr::local_tempfile(fileext = ".geojson")
   cc <- suppressMessages(geojson_write(us_cities[1:2, ], lat = "lat", lon = "long", precision = 2, file = gwf3))
   expect_s3_class(cc, "geojson_file")
   cc_txt <- gsub("\\s+", " ", paste0(readLines(gwf3), collapse = ""))
@@ -38,7 +38,7 @@ test_that("precision argument works with points in geojson_write", {
     "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"name\":\"Abilene TX\",\"country.etc\":\"TX\",\"pop\":113888,\"lat\":32.45,\"long\":-99.74,\"capital\":0},\"geometry\":{\"type\":\"Point\",\"coordinates\":[-99.74,32.45]}},{\"type\":\"Feature\",\"properties\":{\"name\":\"Akron OH\",\"country.etc\":\"OH\",\"pop\":206634,\"lat\":41.08,\"long\":-81.52,\"capital\":0},\"geometry\":{\"type\":\"Point\",\"coordinates\":[-81.52,41.08]}}]}"
   )
 
-  gwf4 <- tempfile(fileext = ".geojson")
+  gwf4 <- withr::local_tempfile(fileext = ".geojson")
   d <- suppressMessages(geojson_write(us_cities[1:2, ], lat = "lat", lon = "long", precision = 1, file = gwf4))
   expect_s3_class(d, "geojson_file")
   d_txt <- gsub("\\s+", " ", paste0(readLines(gwf4), collapse = ""))
@@ -62,7 +62,7 @@ test_that("precision argument works with sp objects in geojson_write", {
   ))), "2")
   sp_poly <- SpatialPolygons(list(poly1, poly2), 1:2)
 
-  gwf5 <- tempfile(fileext = ".geojson")
+  gwf5 <- withr::local_tempfile(fileext = ".geojson")
   e <- suppressMessages(geojson_write(sp_poly, file = gwf5))
   expect_s3_class(e, "geojson_file")
   e_txt <- gsub("\\s+", " ", paste0(readLines(gwf5), collapse = ""))
@@ -71,7 +71,7 @@ test_that("precision argument works with sp objects in geojson_write", {
     "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"dummy\":0},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[-100.111,40.111],[-90.111,50.111],[-85.111,45.111],[-100.111,40.111]]]}},{\"type\":\"Feature\",\"properties\":{\"dummy\":0},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[-90.111,30.111],[-80.111,40.111],[-75.111,35.111],[-90.111,30.111]]]}}]}"
   )
 
-  gwf6 <- tempfile(fileext = ".geojson")
+  gwf6 <- withr::local_tempfile(fileext = ".geojson")
   f <- suppressMessages(geojson_write(sp_poly, precision = 2, file = gwf6))
   expect_s3_class(f, "geojson_file")
   f_txt <- gsub("\\s+", " ", paste0(readLines(gwf6), collapse = ""))
@@ -88,7 +88,7 @@ test_that("geojson_write detects inproper polygons passed as lists inputs", {
   bad <- list(c(100.0, 0.0), c(101.0, 0.0), c(101.0, 1.0), c(100.0, 1.0), c(100.0, 1))
 
   # fine
-  gwf7 <- tempfile(fileext = ".geojson")
+  gwf7 <- withr::local_tempfile(fileext = ".geojson")
   fine <- supw(suppressMessages(geojson_write(good, geometry = "polygon", file = gwf7)))
   expect_s3_class(fine, "geojson_file")
   expect_type(fine[[1]], "character")
@@ -117,7 +117,7 @@ test_that("geojson_write unclasses columns with special classes so writeOGR work
       b = ordered("z")
     )
   )
-  gwf8 <- tempfile(fileext = ".geojson")
+  gwf8 <- withr::local_tempfile(fileext = ".geojson")
   expect_s3_class(geojson_write(spdf, file = gwf8), "geojson_file")
   spdf2 <- as(sf::st_read(gwf8, quiet = TRUE, stringsAsFactors = FALSE), "Spatial")
   expect_type(spdf2@data$a, "double")
@@ -146,12 +146,12 @@ test_that("geojson_write passes toJSON args", {
     pt_sfc <- st_sfc(p_list)
     pt_sf <- st_sf(x = c(1.1, 2.2, NA_real_), pt_sfc)
 
-    gwf9 <- tempfile(fileext = ".geojson")
+    gwf9 <- withr::local_tempfile(fileext = ".geojson")
 
     geojson_write(pt_sf, file = gwf9)
     expect_equal(readLines(gwf9, warn = FALSE), expected_na_no_pretty)
 
-    gwf10 <- tempfile(fileext = ".geojson")
+    gwf10 <- withr::local_tempfile(fileext = ".geojson")
     geojson_write(pt_sf, file = gwf10, na = "null", pretty = TRUE)
     expect_equal(readLines(gwf10, warn = FALSE), expected_null_pretty)
   }
@@ -181,12 +181,12 @@ test_that("geojson_write passes toJSON args", {
       class = "geo_list"
     )
 
-  gwf11 <- tempfile(fileext = ".geojson")
+  gwf11 <- withr::local_tempfile(fileext = ".geojson")
 
   geojson_write(pt_geo_list, file = gwf11)
   expect_equal(readLines(gwf11, warn = FALSE), expected_na_no_pretty)
 
-  gwf12 <- tempfile(fileext = ".geojson")
+  gwf12 <- withr::local_tempfile(fileext = ".geojson")
   geojson_write(pt_geo_list, file = gwf12, na = "null", pretty = TRUE)
   expect_equal(readLines(gwf12, warn = FALSE), expected_null_pretty)
 })

--- a/tests/testthat/test-geojson_write.R
+++ b/tests/testthat/test-geojson_write.R
@@ -147,10 +147,10 @@ test_that("geojson_write passes toJSON args", {
     "}"
   )
 
-  if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
-    p_list <- lapply(list(c(3.2, 4), c(3, 4.6), c(3.8, 4.4)), st_point)
-    pt_sfc <- st_sfc(p_list)
-    pt_sf <- st_sf(x = c(1.1, 2.2, NA_real_), pt_sfc)
+  if (requireNamespace("sf", quietly = TRUE)) {
+    p_list <- lapply(list(c(3.2, 4), c(3, 4.6), c(3.8, 4.4)), sf::st_point)
+    pt_sfc <- sf::st_sfc(p_list)
+    pt_sf <- sf::st_sf(x = c(1.1, 2.2, NA_real_), pt_sfc)
 
     gwf9 <- withr::local_tempfile(fileext = ".geojson")
 

--- a/tests/testthat/test-geojson_write.R
+++ b/tests/testthat/test-geojson_write.R
@@ -125,9 +125,11 @@ test_that("geojson_write unclasses columns with special classes so writeOGR work
   )
   gwf8 <- withr::local_tempfile(fileext = ".geojson")
   expect_s3_class(geojson_write(spdf, file = gwf8), "geojson_file")
-  spdf2 <- as(sf::st_read(gwf8, quiet = TRUE, stringsAsFactors = FALSE), "Spatial")
-  expect_type(spdf2@data$a, "double")
-  expect_type(spdf2@data$b, "character")
+  if (requireNamespace("sf", quietly = TRUE)) {
+    spdf2 <- as(sf::st_read(gwf8, quiet = TRUE, stringsAsFactors = FALSE), "Spatial")
+    expect_type(spdf2@data$a, "double")
+    expect_type(spdf2@data$b, "character")
+  }
 })
 
 test_that("geojson_write passes toJSON args", {

--- a/tests/testthat/test-map_gist.R
+++ b/tests/testthat/test-map_gist.R
@@ -6,13 +6,13 @@ test_that("map_gist works with file inputs", {
   skip_on_cran()
 
   file <- withr::local_tempfile(fileext = ".geojson")
-  geojson_write(us_cities[1:20, ], lat = "lat", lon = "long", file = file)
+  supm(geojson_write(us_cities[1:20, ], lat = "lat", lon = "long", file = file))
   a <- map_gist(file = as.location(file), browse = FALSE)
   expect_s3_class(a, "gist")
   expect_type(a$url, "character")
   expect_named(a$files, basename(file))
 
-  gdel(a)
+  supm(gistr::delete(a))
 })
 
 test_that("map_gist works with geo_list inputs", {
@@ -21,11 +21,11 @@ test_that("map_gist works with geo_list inputs", {
   file <- withr::local_tempfile(fileext = ".geojson")
 
   res <- geojson_list(us_cities[1:2, ], lat = "lat", lon = "long")
-  b <- map_gist(res, browse = FALSE, file = file)
+  b <- supm(map_gist(res, browse = FALSE, file = file))
   expect_s3_class(res, "geo_list")
   expect_s3_class(b, "gist")
 
-  gdel(b)
+  supm(gistr::delete(b))
 })
 
 test_that("map_gist works with json inputs", {
@@ -34,12 +34,12 @@ test_that("map_gist works with json inputs", {
   file <- withr::local_tempfile(fileext = ".geojson")
 
   x <- geojson_json(c(-99.74, 32.45))
-  f <- map_gist(x, browse = FALSE, file = file)
+  f <- supm(map_gist(x, browse = FALSE, file = file))
   expect_s3_class(x, "json")
   expect_s3_class(f, "gist")
   expect_type(f$git_pull_url, "character")
 
-  gdel(f)
+  supm(gistr::delete(f))
 })
 
 test_that("map_gist works with SpatialPoints inputs", {
@@ -50,12 +50,12 @@ test_that("map_gist works with SpatialPoints inputs", {
   a <- c(1, 2, 3, 4, 5)
   b <- c(3, 2, 5, 1, 4)
   x <- SpatialPoints(cbind(a, b))
-  g <- map_gist(x, browse = FALSE, file = file)
+  g <- supm(map_gist(x, browse = FALSE, file = file))
   expect_s3_class(g, "gist")
   expect_type(g$url, "character")
   expect_named(g$files, basename(file))
 
-  gdel(g)
+  supm(gistr::delete(g))
 })
 
 test_that("map_gist works with SpatialPointsDataFrame inputs", {
@@ -66,12 +66,12 @@ test_that("map_gist works with SpatialPointsDataFrame inputs", {
   a <- c(1, 2, 3, 4, 5)
   b <- c(3, 2, 5, 1, 4)
   s <- SpatialPointsDataFrame(cbind(a, b), mtcars[1:5, ])
-  h <- supw(map_gist(s, browse = FALSE, file = file))
+  h <- supm(map_gist(s, browse = FALSE, file = file))
   expect_s3_class(h, "gist")
   expect_type(h$url, "character")
   expect_named(h$files, basename(file))
 
-  gdel(h)
+  supm(gistr::delete(h))
 })
 
 test_that("map_gist works with SpatialPolygons inputs", {
@@ -88,12 +88,12 @@ test_that("map_gist works with SpatialPolygons inputs", {
     c(30, 40, 35, 30)
   ))), "2")
   sp_poly <- SpatialPolygons(list(poly1, poly2), 1:2)
-  i <- map_gist(sp_poly, browse = FALSE, file = file)
+  i <- supm(map_gist(sp_poly, browse = FALSE, file = file))
   expect_s3_class(i, "gist")
   expect_type(i$url, "character")
   expect_named(i$files, basename(file))
 
-  gdel(i)
+  supm(gistr::delete(i))
 })
 
 test_that("map_gist works with data.frame inputs", {
@@ -101,10 +101,10 @@ test_that("map_gist works with data.frame inputs", {
 
   file <- withr::local_tempfile(fileext = ".geojson")
 
-  j <- map_gist(us_cities[1:50, ], browse = FALSE, file = file)
+  j <- supm(map_gist(us_cities[1:50, ], browse = FALSE, file = file))
   expect_s3_class(j, "gist")
 
-  gdel(j)
+  supm(gistr::delete(j))
 })
 
 test_that("map_gist works with data.frame inputs", {
@@ -112,8 +112,8 @@ test_that("map_gist works with data.frame inputs", {
 
   file <- withr::local_tempfile(fileext = ".geojson")
 
-  k <- map_gist(c(32.45, -99.74), browse = FALSE, file = file)
+  k <- supm(map_gist(c(32.45, -99.74), browse = FALSE, file = file))
   expect_s3_class(k, "gist")
 
-  gdel(k)
+  supm(gistr::delete(k))
 })

--- a/tests/testthat/test-map_gist.R
+++ b/tests/testthat/test-map_gist.R
@@ -5,12 +5,12 @@ skip_on_cran()
 test_that("map_gist works with file inputs", {
   skip_on_cran()
 
-  tfile <- tempfile(fileext = ".geojson")
-  geojson_write(us_cities[1:20, ], lat = "lat", lon = "long", file = tfile)
-  a <- map_gist(file = as.location(tfile), browse = FALSE)
+  file <- withr::local_tempfile(fileext = ".geojson")
+  geojson_write(us_cities[1:20, ], lat = "lat", lon = "long", file = file)
+  a <- map_gist(file = as.location(file), browse = FALSE)
   expect_s3_class(a, "gist")
   expect_type(a$url, "character")
-  expect_named(a$files, basename(tfile))
+  expect_named(a$files, basename(file))
 
   gdel(a)
 })
@@ -18,8 +18,10 @@ test_that("map_gist works with file inputs", {
 test_that("map_gist works with geo_list inputs", {
   skip_on_cran()
 
+  file <- withr::local_tempfile(fileext = ".geojson")
+
   res <- geojson_list(us_cities[1:2, ], lat = "lat", lon = "long")
-  b <- map_gist(res, browse = FALSE)
+  b <- map_gist(res, browse = FALSE, file = file)
   expect_s3_class(res, "geo_list")
   expect_s3_class(b, "gist")
 
@@ -29,8 +31,10 @@ test_that("map_gist works with geo_list inputs", {
 test_that("map_gist works with json inputs", {
   skip_on_cran()
 
+  file <- withr::local_tempfile(fileext = ".geojson")
+
   x <- geojson_json(c(-99.74, 32.45))
-  f <- map_gist(x, browse = FALSE)
+  f <- map_gist(x, browse = FALSE, file = file)
   expect_s3_class(x, "json")
   expect_s3_class(f, "gist")
   expect_type(f$git_pull_url, "character")
@@ -41,13 +45,15 @@ test_that("map_gist works with json inputs", {
 test_that("map_gist works with SpatialPoints inputs", {
   skip_on_cran()
 
+  file <- withr::local_tempfile(fileext = ".geojson")
+
   a <- c(1, 2, 3, 4, 5)
   b <- c(3, 2, 5, 1, 4)
   x <- SpatialPoints(cbind(a, b))
-  g <- map_gist(x, browse = FALSE)
+  g <- map_gist(x, browse = FALSE, file = file)
   expect_s3_class(g, "gist")
   expect_type(g$url, "character")
-  expect_named(g$files, "myfile.geojson")
+  expect_named(g$files, basename(file))
 
   gdel(g)
 })
@@ -55,19 +61,23 @@ test_that("map_gist works with SpatialPoints inputs", {
 test_that("map_gist works with SpatialPointsDataFrame inputs", {
   skip_on_cran()
 
+  file <- withr::local_tempfile(fileext = ".geojson")
+
   a <- c(1, 2, 3, 4, 5)
   b <- c(3, 2, 5, 1, 4)
   s <- SpatialPointsDataFrame(cbind(a, b), mtcars[1:5, ])
-  h <- supw(map_gist(s, browse = FALSE))
+  h <- supw(map_gist(s, browse = FALSE, file = file))
   expect_s3_class(h, "gist")
   expect_type(h$url, "character")
-  expect_named(h$files, "myfile.geojson")
+  expect_named(h$files, basename(file))
 
   gdel(h)
 })
 
 test_that("map_gist works with SpatialPolygons inputs", {
   skip_on_cran()
+
+  file <- withr::local_tempfile(fileext = ".geojson")
 
   poly1 <- Polygons(list(Polygon(cbind(
     c(-100, -90, -85, -100),
@@ -78,10 +88,10 @@ test_that("map_gist works with SpatialPolygons inputs", {
     c(30, 40, 35, 30)
   ))), "2")
   sp_poly <- SpatialPolygons(list(poly1, poly2), 1:2)
-  i <- map_gist(sp_poly, browse = FALSE)
+  i <- map_gist(sp_poly, browse = FALSE, file = file)
   expect_s3_class(i, "gist")
   expect_type(i$url, "character")
-  expect_named(i$files, "myfile.geojson")
+  expect_named(i$files, basename(file))
 
   gdel(i)
 })
@@ -89,7 +99,9 @@ test_that("map_gist works with SpatialPolygons inputs", {
 test_that("map_gist works with data.frame inputs", {
   skip_on_cran()
 
-  j <- map_gist(us_cities[1:50, ], browse = FALSE)
+  file <- withr::local_tempfile(fileext = ".geojson")
+
+  j <- map_gist(us_cities[1:50, ], browse = FALSE, file = file)
   expect_s3_class(j, "gist")
 
   gdel(j)
@@ -98,7 +110,9 @@ test_that("map_gist works with data.frame inputs", {
 test_that("map_gist works with data.frame inputs", {
   skip_on_cran()
 
-  k <- map_gist(c(32.45, -99.74), browse = FALSE)
+  file <- withr::local_tempfile(fileext = ".geojson")
+
+  k <- map_gist(c(32.45, -99.74), browse = FALSE, file = file)
   expect_s3_class(k, "gist")
 
   gdel(k)

--- a/tests/testthat/test-map_gist.R
+++ b/tests/testthat/test-map_gist.R
@@ -41,7 +41,6 @@ test_that("map_gist works with json inputs", {
 test_that("map_gist works with SpatialPoints inputs", {
   skip_on_cran()
 
-  library("sp")
   a <- c(1, 2, 3, 4, 5)
   b <- c(3, 2, 5, 1, 4)
   x <- SpatialPoints(cbind(a, b))
@@ -56,7 +55,6 @@ test_that("map_gist works with SpatialPoints inputs", {
 test_that("map_gist works with SpatialPointsDataFrame inputs", {
   skip_on_cran()
 
-  library("sp")
   a <- c(1, 2, 3, 4, 5)
   b <- c(3, 2, 5, 1, 4)
   s <- SpatialPointsDataFrame(cbind(a, b), mtcars[1:5, ])

--- a/tests/testthat/test-map_gist.R
+++ b/tests/testthat/test-map_gist.R
@@ -5,79 +5,74 @@ skip_on_cran()
 test_that("map_gist works with file inputs", {
   skip_on_cran()
 
-  file <- withr::local_tempfile(fileext = ".geojson")
+  file <- local_gist_temp_file()
   supm(geojson_write(us_cities[1:20, ], lat = "lat", lon = "long", file = file))
-  a <- map_gist(file = as.location(file), browse = FALSE)
-  expect_s3_class(a, "gist")
-  expect_type(a$url, "character")
-  expect_named(a$files, basename(file))
+  g <- temp_map_gist(file = as.location(file), browse = FALSE)
 
-  supm(gistr::delete(a))
+  expect_s3_class(g, "gist")
+  expect_type(g$url, "character")
+  expect_named(g$files, basename(file))
 })
 
 test_that("map_gist works with geo_list inputs", {
   skip_on_cran()
 
-  file <- withr::local_tempfile(fileext = ".geojson")
+  file <- local_gist_temp_file()
 
   res <- geojson_list(us_cities[1:2, ], lat = "lat", lon = "long")
-  b <- supm(map_gist(res, browse = FALSE, file = file))
-  expect_s3_class(res, "geo_list")
-  expect_s3_class(b, "gist")
+  g <- temp_map_gist(res, browse = FALSE, file = file)
 
-  supm(gistr::delete(b))
+  expect_s3_class(res, "geo_list")
+  expect_s3_class(g, "gist")
 })
 
 test_that("map_gist works with json inputs", {
   skip_on_cran()
 
-  file <- withr::local_tempfile(fileext = ".geojson")
+  file <- local_gist_temp_file()
 
   x <- geojson_json(c(-99.74, 32.45))
-  f <- supm(map_gist(x, browse = FALSE, file = file))
-  expect_s3_class(x, "json")
-  expect_s3_class(f, "gist")
-  expect_type(f$git_pull_url, "character")
+  g <- temp_map_gist(x, browse = FALSE, file = file)
 
-  supm(gistr::delete(f))
+  expect_s3_class(x, "json")
+  expect_s3_class(g, "gist")
+  expect_type(g$git_pull_url, "character")
 })
 
 test_that("map_gist works with SpatialPoints inputs", {
   skip_on_cran()
 
-  file <- withr::local_tempfile(fileext = ".geojson")
+  file <- local_gist_temp_file()
 
   a <- c(1, 2, 3, 4, 5)
   b <- c(3, 2, 5, 1, 4)
   x <- SpatialPoints(cbind(a, b))
-  g <- supm(map_gist(x, browse = FALSE, file = file))
+  g <- temp_map_gist(x, browse = FALSE, file = file)
+
   expect_s3_class(g, "gist")
   expect_type(g$url, "character")
   expect_named(g$files, basename(file))
-
-  supm(gistr::delete(g))
 })
 
 test_that("map_gist works with SpatialPointsDataFrame inputs", {
   skip_on_cran()
 
-  file <- withr::local_tempfile(fileext = ".geojson")
+  file <- local_gist_temp_file()
 
   a <- c(1, 2, 3, 4, 5)
   b <- c(3, 2, 5, 1, 4)
   s <- SpatialPointsDataFrame(cbind(a, b), mtcars[1:5, ])
-  h <- supm(map_gist(s, browse = FALSE, file = file))
-  expect_s3_class(h, "gist")
-  expect_type(h$url, "character")
-  expect_named(h$files, basename(file))
+  g <- temp_map_gist(s, browse = FALSE, file = file)
 
-  supm(gistr::delete(h))
+  expect_s3_class(g, "gist")
+  expect_type(g$url, "character")
+  expect_named(g$files, basename(file))
 })
 
 test_that("map_gist works with SpatialPolygons inputs", {
   skip_on_cran()
 
-  file <- withr::local_tempfile(fileext = ".geojson")
+  file <- local_gist_temp_file()
 
   poly1 <- Polygons(list(Polygon(cbind(
     c(-100, -90, -85, -100),
@@ -88,32 +83,25 @@ test_that("map_gist works with SpatialPolygons inputs", {
     c(30, 40, 35, 30)
   ))), "2")
   sp_poly <- SpatialPolygons(list(poly1, poly2), 1:2)
-  i <- supm(map_gist(sp_poly, browse = FALSE, file = file))
-  expect_s3_class(i, "gist")
-  expect_type(i$url, "character")
-  expect_named(i$files, basename(file))
+  g <- temp_map_gist(sp_poly, browse = FALSE, file = file)
 
-  supm(gistr::delete(i))
+  expect_s3_class(g, "gist")
+  expect_type(g$url, "character")
+  expect_named(g$files, basename(file))
 })
 
 test_that("map_gist works with data.frame inputs", {
   skip_on_cran()
 
-  file <- withr::local_tempfile(fileext = ".geojson")
-
-  j <- supm(map_gist(us_cities[1:50, ], browse = FALSE, file = file))
-  expect_s3_class(j, "gist")
-
-  supm(gistr::delete(j))
+  file <- local_gist_temp_file()
+  g <- temp_map_gist(us_cities[1:50, ], browse = FALSE, file = file)
+  expect_s3_class(g, "gist")
 })
 
 test_that("map_gist works with data.frame inputs", {
   skip_on_cran()
 
-  file <- withr::local_tempfile(fileext = ".geojson")
-
-  k <- supm(map_gist(c(32.45, -99.74), browse = FALSE, file = file))
-  expect_s3_class(k, "gist")
-
-  supm(gistr::delete(k))
+  file <- local_gist_temp_file()
+  g <- temp_map_gist(c(32.45, -99.74), browse = FALSE, file = file)
+  expect_s3_class(g, "gist")
 })

--- a/tests/testthat/test-mapleaflet.R
+++ b/tests/testthat/test-mapleaflet.R
@@ -79,17 +79,16 @@ test_that("map_leaf works with list inputs", {
 
 test_that("map_leaf works with SpatialPolygons inputs", {
   skip_on_cran()
-  sp_poly <- local({
-    poly1 <- Polygons(list(Polygon(cbind(
-      c(-100, -90, -85, -100),
-      c(40, 50, 45, 40)
-    ))), "1")
-    poly2 <- Polygons(list(Polygon(cbind(
-      c(-90, -80, -75, -90),
-      c(30, 40, 35, 30)
-    ))), "2")
-    SpatialPolygons(list(poly1, poly2), 1:2)
-  })
+
+  poly1 <- Polygons(list(Polygon(cbind(
+    c(-100, -90, -85, -100),
+    c(40, 50, 45, 40)
+  ))), "1")
+  poly2 <- Polygons(list(Polygon(cbind(
+    c(-90, -80, -75, -90),
+    c(30, 40, 35, 30)
+  ))), "2")
+  sp_poly <- SpatialPolygons(list(poly1, poly2), 1:2)
   jj <- map_leaf(sp_poly)
 
   expect_s3_class(jj, "leaflet")
@@ -97,17 +96,16 @@ test_that("map_leaf works with SpatialPolygons inputs", {
 
 test_that("map_leaf works with SpatialPolygonsDataFrame inputs", {
   skip_on_cran()
-  sp_poly <- local({
-    poly1 <- Polygons(list(Polygon(cbind(
-      c(-100, -90, -85, -100),
-      c(40, 50, 45, 40)
-    ))), "1")
-    poly2 <- Polygons(list(Polygon(cbind(
-      c(-90, -80, -75, -90),
-      c(30, 40, 35, 30)
-    ))), "2")
-    SpatialPolygons(list(poly1, poly2), 1:2)
-  })
+
+  poly1 <- Polygons(list(Polygon(cbind(
+    c(-100, -90, -85, -100),
+    c(40, 50, 45, 40)
+  ))), "1")
+  poly2 <- Polygons(list(Polygon(cbind(
+    c(-90, -80, -75, -90),
+    c(30, 40, 35, 30)
+  ))), "2")
+  sp_poly <- SpatialPolygons(list(poly1, poly2), 1:2)
   sp_polydf <- as(sp_poly, "SpatialPolygonsDataFrame")
   jj <- map_leaf(sp_polydf)
 
@@ -116,11 +114,11 @@ test_that("map_leaf works with SpatialPolygonsDataFrame inputs", {
 
 test_that("map_leaf works with SpatialPoints inputs", {
   skip_on_cran()
-  sp_pts <- local({
-    a <- c(1, 2, 3, 4, 5)
-    b <- c(3, 2, 5, 1, 4)
-    SpatialPoints(cbind(a, b))
-  })
+
+  sp_pts <- SpatialPoints(cbind(
+    c(1, 2, 3, 4, 5),
+    c(3, 2, 5, 1, 4)
+  ))
   kk <- map_leaf(sp_pts)
   expect_s4_class(sp_pts, "SpatialPoints")
   expect_s3_class(kk, "leaflet")
@@ -128,11 +126,10 @@ test_that("map_leaf works with SpatialPoints inputs", {
 
 test_that("map_leaf works with SpatialPointsDataFrame inputs", {
   skip_on_cran()
-  sp_pts <- local({
-    a <- c(1, 2, 3, 4, 5)
-    b <- c(3, 2, 5, 1, 4)
-    SpatialPoints(cbind(a, b))
-  })
+  sp_pts <- SpatialPoints(cbind(
+    c(1, 2, 3, 4, 5),
+    c(3, 2, 5, 1, 4)
+  ))
   sp_ptsdf <- as(sp_pts, "SpatialPointsDataFrame")
   ll <- map_leaf(sp_ptsdf)
   expect_s4_class(sp_ptsdf, "SpatialPointsDataFrame")
@@ -141,12 +138,11 @@ test_that("map_leaf works with SpatialPointsDataFrame inputs", {
 
 test_that("map_leaf works with SpatialLines inputs", {
   skip_on_cran()
-  sp_lines <- local({
-    c1 <- cbind(c(1, 2, 3), c(3, 2, 2))
-    L1 <- Line(c1)
-    Ls1 <- Lines(list(L1), ID = "a")
-    SpatialLines(list(Ls1))
-  })
+
+  c1 <- cbind(c(1, 2, 3), c(3, 2, 2))
+  L1 <- Line(c1)
+  Ls1 <- Lines(list(L1), ID = "a")
+  sp_lines <- SpatialLines(list(Ls1))
 
   mm <- map_leaf(sp_lines)
   expect_s4_class(sp_lines, "SpatialLines")
@@ -155,12 +151,11 @@ test_that("map_leaf works with SpatialLines inputs", {
 
 test_that("map_leaf works with SpatialLinesDataFrame inputs", {
   skip_on_cran()
-  sp_lines <- local({
-    c1 <- cbind(c(1, 2, 3), c(3, 2, 2))
-    L1 <- Line(c1)
-    Ls1 <- Lines(list(L1), ID = "a")
-    SpatialLines(list(Ls1))
-  })
+
+  c1 <- cbind(c(1, 2, 3), c(3, 2, 2))
+  L1 <- Line(c1)
+  Ls1 <- Lines(list(L1), ID = "a")
+  sp_lines <- SpatialLines(list(Ls1))
 
   sp_linesdf <- as(sp_lines, "SpatialLinesDataFrame")
   nn <- map_leaf(sp_linesdf)
@@ -171,10 +166,7 @@ test_that("map_leaf works with SpatialLinesDataFrame inputs", {
 test_that("map_leaf works with SpatialGrid inputs", {
   skip_on_cran()
 
-  sp_grid <- local({
-    x <- GridTopology(c(0, 0), c(1, 1), c(5, 5))
-    SpatialGrid(x)
-  })
+  sp_grid <- SpatialGrid(GridTopology(c(0, 0), c(1, 1), c(5, 5)))
   mm <- map_leaf(sp_grid)
   expect_s4_class(sp_grid, "SpatialGrid")
   expect_s3_class(mm, "leaflet")
@@ -183,10 +175,7 @@ test_that("map_leaf works with SpatialGrid inputs", {
 test_that("map_leaf works with SpatialGridDataFrame inputs", {
   skip_on_cran()
 
-  sp_grid <- local({
-    x <- GridTopology(c(0, 0), c(1, 1), c(5, 5))
-    SpatialGrid(x)
-  })
+  sp_grid <- SpatialGrid(GridTopology(c(0, 0), c(1, 1), c(5, 5)))
   sp_griddf <- SpatialGridDataFrame(sp_grid, data.frame(val = 1:25))
   nn <- map_leaf(sp_griddf)
   expect_s4_class(sp_griddf, "SpatialGridDataFrame")

--- a/tests/testthat/test-mapleaflet.R
+++ b/tests/testthat/test-mapleaflet.R
@@ -1,7 +1,3 @@
-skip_on_cran()
-
-supp_invis <- function(x) suppressMessages(invisible(x))
-
 test_that("map_leaf works with file inputs", {
   skip_on_cran()
   file <- withr::local_file(tempfile(fileext = ".geojson"))
@@ -79,40 +75,21 @@ test_that("map_leaf works with list inputs", {
   expect_s3_class(ii_map, "leaflet")
 })
 
-
 ## spatial classes --------------
-sp_poly <- local({
-  poly1 <- Polygons(list(Polygon(cbind(
-    c(-100, -90, -85, -100),
-    c(40, 50, 45, 40)
-  ))), "1")
-  poly2 <- Polygons(list(Polygon(cbind(
-    c(-90, -80, -75, -90),
-    c(30, 40, 35, 30)
-  ))), "2")
-  SpatialPolygons(list(poly1, poly2), 1:2)
-})
-
-sp_pts <- local({
-  a <- c(1, 2, 3, 4, 5)
-  b <- c(3, 2, 5, 1, 4)
-  SpatialPoints(cbind(a, b))
-})
-
-sp_lines <- local({
-  c1 <- cbind(c(1, 2, 3), c(3, 2, 2))
-  L1 <- Line(c1)
-  Ls1 <- Lines(list(L1), ID = "a")
-  SpatialLines(list(Ls1))
-})
-
-sp_grid <- local({
-  x <- GridTopology(c(0, 0), c(1, 1), c(5, 5))
-  SpatialGrid(x)
-})
 
 test_that("map_leaf works with SpatialPolygons inputs", {
   skip_on_cran()
+  sp_poly <- local({
+    poly1 <- Polygons(list(Polygon(cbind(
+      c(-100, -90, -85, -100),
+      c(40, 50, 45, 40)
+    ))), "1")
+    poly2 <- Polygons(list(Polygon(cbind(
+      c(-90, -80, -75, -90),
+      c(30, 40, 35, 30)
+    ))), "2")
+    SpatialPolygons(list(poly1, poly2), 1:2)
+  })
   jj <- map_leaf(sp_poly)
 
   expect_s3_class(jj, "leaflet")
@@ -120,6 +97,17 @@ test_that("map_leaf works with SpatialPolygons inputs", {
 
 test_that("map_leaf works with SpatialPolygonsDataFrame inputs", {
   skip_on_cran()
+  sp_poly <- local({
+    poly1 <- Polygons(list(Polygon(cbind(
+      c(-100, -90, -85, -100),
+      c(40, 50, 45, 40)
+    ))), "1")
+    poly2 <- Polygons(list(Polygon(cbind(
+      c(-90, -80, -75, -90),
+      c(30, 40, 35, 30)
+    ))), "2")
+    SpatialPolygons(list(poly1, poly2), 1:2)
+  })
   sp_polydf <- as(sp_poly, "SpatialPolygonsDataFrame")
   jj <- map_leaf(sp_polydf)
 
@@ -128,6 +116,11 @@ test_that("map_leaf works with SpatialPolygonsDataFrame inputs", {
 
 test_that("map_leaf works with SpatialPoints inputs", {
   skip_on_cran()
+  sp_pts <- local({
+    a <- c(1, 2, 3, 4, 5)
+    b <- c(3, 2, 5, 1, 4)
+    SpatialPoints(cbind(a, b))
+  })
   kk <- map_leaf(sp_pts)
   expect_s4_class(sp_pts, "SpatialPoints")
   expect_s3_class(kk, "leaflet")
@@ -135,6 +128,11 @@ test_that("map_leaf works with SpatialPoints inputs", {
 
 test_that("map_leaf works with SpatialPointsDataFrame inputs", {
   skip_on_cran()
+  sp_pts <- local({
+    a <- c(1, 2, 3, 4, 5)
+    b <- c(3, 2, 5, 1, 4)
+    SpatialPoints(cbind(a, b))
+  })
   sp_ptsdf <- as(sp_pts, "SpatialPointsDataFrame")
   ll <- map_leaf(sp_ptsdf)
   expect_s4_class(sp_ptsdf, "SpatialPointsDataFrame")
@@ -143,6 +141,13 @@ test_that("map_leaf works with SpatialPointsDataFrame inputs", {
 
 test_that("map_leaf works with SpatialLines inputs", {
   skip_on_cran()
+  sp_lines <- local({
+    c1 <- cbind(c(1, 2, 3), c(3, 2, 2))
+    L1 <- Line(c1)
+    Ls1 <- Lines(list(L1), ID = "a")
+    SpatialLines(list(Ls1))
+  })
+
   mm <- map_leaf(sp_lines)
   expect_s4_class(sp_lines, "SpatialLines")
   expect_s3_class(mm, "leaflet")
@@ -150,6 +155,13 @@ test_that("map_leaf works with SpatialLines inputs", {
 
 test_that("map_leaf works with SpatialLinesDataFrame inputs", {
   skip_on_cran()
+  sp_lines <- local({
+    c1 <- cbind(c(1, 2, 3), c(3, 2, 2))
+    L1 <- Line(c1)
+    Ls1 <- Lines(list(L1), ID = "a")
+    SpatialLines(list(Ls1))
+  })
+
   sp_linesdf <- as(sp_lines, "SpatialLinesDataFrame")
   nn <- map_leaf(sp_linesdf)
   expect_s4_class(sp_linesdf, "SpatialLinesDataFrame")
@@ -158,6 +170,11 @@ test_that("map_leaf works with SpatialLinesDataFrame inputs", {
 
 test_that("map_leaf works with SpatialGrid inputs", {
   skip_on_cran()
+
+  sp_grid <- local({
+    x <- GridTopology(c(0, 0), c(1, 1), c(5, 5))
+    SpatialGrid(x)
+  })
   mm <- map_leaf(sp_grid)
   expect_s4_class(sp_grid, "SpatialGrid")
   expect_s3_class(mm, "leaflet")
@@ -165,6 +182,11 @@ test_that("map_leaf works with SpatialGrid inputs", {
 
 test_that("map_leaf works with SpatialGridDataFrame inputs", {
   skip_on_cran()
+
+  sp_grid <- local({
+    x <- GridTopology(c(0, 0), c(1, 1), c(5, 5))
+    SpatialGrid(x)
+  })
   sp_griddf <- SpatialGridDataFrame(sp_grid, data.frame(val = 1:25))
   nn <- map_leaf(sp_griddf)
   expect_s4_class(sp_griddf, "SpatialGridDataFrame")

--- a/tests/testthat/test-mapleaflet.R
+++ b/tests/testthat/test-mapleaflet.R
@@ -2,7 +2,7 @@ supp_invis <- function(x) suppressMessages(invisible(x))
 
 test_that("map_leaf works with file inputs", {
   skip_on_cran()
-  file <- "myfile.geojson"
+  file <- withr::local_file(tempfile(fileext = ".geojson"))
   supp_invis(geojson_write(us_cities[1:20, ], lat = "lat", lon = "long", file = file))
   a_map <- map_leaf(as.location(file))
   expect_s3_class(as.location(file), "location_")

--- a/tests/testthat/test-mapleaflet.R
+++ b/tests/testthat/test-mapleaflet.R
@@ -1,7 +1,7 @@
 test_that("map_leaf works with file inputs", {
   skip_on_cran()
   file <- withr::local_file(tempfile(fileext = ".geojson"))
-  supp_invis(geojson_write(us_cities[1:20, ], lat = "lat", lon = "long", file = file))
+  supm(geojson_write(us_cities[1:20, ], lat = "lat", lon = "long", file = file))
   a_map <- map_leaf(as.location(file))
   expect_s3_class(as.location(file), "location_")
   expect_s3_class(a_map, "leaflet")
@@ -28,7 +28,7 @@ test_that("map_leaf works with geo_list inputs", {
     list(latitude = 30, longitude = 120, marker = "red"),
     list(latitude = 30, longitude = 130, marker = "blue")
   )
-  x <- suppressMessages(geojson_list(mylist))
+  x <- supm(geojson_list(mylist))
   c_map <- map_leaf(x)
   expect_s3_class(x, "geo_list")
   expect_s3_class(c_map, "leaflet")
@@ -53,7 +53,7 @@ test_that("map_leaf works with json inputs", {
 
 test_that("map_leaf works with data.frame inputs", {
   skip_on_cran()
-  h_map <- supp_invis(map_leaf(us_cities, basemap = "CartoDB.Positron"))
+  h_map <- supm(map_leaf(us_cities, basemap = "CartoDB.Positron"))
   expect_s3_class(h_map, "leaflet")
 })
 
@@ -71,7 +71,7 @@ test_that("map_leaf works with list inputs", {
     c(-106.61132812499999, 39.436192999314095),
     c(-114.345703125, 39.436192999314095)
   )
-  ii_map <- supp_invis(map_leaf(poly))
+  ii_map <- supm(map_leaf(poly))
   expect_s3_class(ii_map, "leaflet")
 })
 

--- a/tests/testthat/test-mapleaflet.R
+++ b/tests/testthat/test-mapleaflet.R
@@ -1,4 +1,3 @@
-library("leaflet")
 supp_invis <- function(x) suppressMessages(invisible(x))
 
 test_that("map_leaf works with file inputs", {
@@ -82,7 +81,6 @@ test_that("map_leaf works with list inputs", {
 
 ## spatial classes --------------
 sp_poly <- local({
-  library("sp")
   poly1 <- Polygons(list(Polygon(cbind(
     c(-100, -90, -85, -100),
     c(40, 50, 45, 40)
@@ -95,14 +93,12 @@ sp_poly <- local({
 })
 
 sp_pts <- local({
-  library("sp")
   a <- c(1, 2, 3, 4, 5)
   b <- c(3, 2, 5, 1, 4)
   SpatialPoints(cbind(a, b))
 })
 
 sp_lines <- local({
-  library("sp")
   c1 <- cbind(c(1, 2, 3), c(3, 2, 2))
   L1 <- Line(c1)
   Ls1 <- Lines(list(L1), ID = "a")
@@ -110,7 +106,6 @@ sp_lines <- local({
 })
 
 sp_grid <- local({
-  library("sp")
   x <- GridTopology(c(0, 0), c(1, 1), c(5, 5))
   SpatialGrid(x)
 })

--- a/tests/testthat/test-mapleaflet.R
+++ b/tests/testthat/test-mapleaflet.R
@@ -75,7 +75,7 @@ test_that("map_leaf works with list inputs", {
   expect_s3_class(ii_map, "leaflet")
 })
 
-## spatial classes --------------
+## spatial classes
 
 test_that("map_leaf works with SpatialPolygons inputs", {
   skip_on_cran()

--- a/tests/testthat/test-mapleaflet.R
+++ b/tests/testthat/test-mapleaflet.R
@@ -1,3 +1,5 @@
+skip_on_cran()
+
 supp_invis <- function(x) suppressMessages(invisible(x))
 
 test_that("map_leaf works with file inputs", {
@@ -78,7 +80,6 @@ test_that("map_leaf works with list inputs", {
 })
 
 
-
 ## spatial classes --------------
 sp_poly <- local({
   poly1 <- Polygons(list(Polygon(cbind(
@@ -154,7 +155,6 @@ test_that("map_leaf works with SpatialLinesDataFrame inputs", {
   expect_s4_class(sp_linesdf, "SpatialLinesDataFrame")
   expect_s3_class(nn, "leaflet")
 })
-
 
 test_that("map_leaf works with SpatialGrid inputs", {
   skip_on_cran()

--- a/tests/testthat/test-onload.R
+++ b/tests/testthat/test-onload.R
@@ -1,11 +1,10 @@
-skip_on_cran()
-
-obj_names <- c(
-  "eval", "assign", "validate", "call",
-  "reset", "source", "console", "get"
-)
-
 test_that("onload for turf-extent worked", {
+  skip_on_cran()
+
+  obj_names <- c(
+    "eval", "assign", "validate", "call",
+    "reset", "source", "console", "get"
+  )
   expect_s3_class(ext, "V8")
   expect_true(all(obj_names %in% ls(ext)))
   expect_true(any(grepl("extent", ext$get(leaflet::JS("Object.keys(global)")))))

--- a/tests/testthat/test-onload.R
+++ b/tests/testthat/test-onload.R
@@ -8,5 +8,5 @@ obj_names <- c(
 test_that("onload for turf-extent worked", {
   expect_s3_class(ext, "V8")
   expect_true(all(obj_names %in% ls(ext)))
-  expect_true(any(grepl("extent", ext$get(JS("Object.keys(global)")))))
+  expect_true(any(grepl("extent", ext$get(leaflet::JS("Object.keys(global)")))))
 })

--- a/tests/testthat/test-projections.R
+++ b/tests/testthat/test-projections.R
@@ -1,6 +1,6 @@
-skip_on_cran()
-
 test_that("projections works with different projection names", {
+  skip_on_cran()
+
   expect_type(projections("albers"), "character")
   expect_type(projections("orthographic"), "character")
   expect_type(projections("conicEqualArea"), "character")
@@ -12,6 +12,8 @@ test_that("projections works with different projection names", {
 })
 
 test_that("projections works with rotate parameter", {
+  skip_on_cran()
+
   aa <- projections(proj = "albers", rotate = "[98 + 00 / 60, -35 - 00 / 60]", scale = 5700)
 
   expect_type(aa, "character")
@@ -21,6 +23,8 @@ test_that("projections works with rotate parameter", {
 })
 
 test_that("projections works with scale parameter", {
+  skip_on_cran()
+
   aa <- projections(proj = "albers", scale = 5700)
 
   expect_type(aa, "character")
@@ -28,6 +32,8 @@ test_that("projections works with scale parameter", {
 })
 
 test_that("projections works with translate parameter", {
+  skip_on_cran()
+
   aa <- projections(proj = "albers", translate = "[55 * width / 100, 52 * height / 100]")
 
   expect_type(aa, "character")
@@ -36,6 +42,8 @@ test_that("projections works with translate parameter", {
 })
 
 test_that("projections works with clipAngle parameter", {
+  skip_on_cran()
+
   aa <- projections(proj = "albers", clipAngle = 90)
 
   expect_type(aa, "character")
@@ -43,6 +51,8 @@ test_that("projections works with clipAngle parameter", {
 })
 
 test_that("projections fails well", {
+  skip_on_cran()
+
   expect_error(projections(), "You must provide a character string to 'proj'")
   ## FIXME - add tests for, and make changes to fxn, for forcing inputs to be of correct type
 

--- a/tests/testthat/test-sf_classes.R
+++ b/tests/testthat/test-sf_classes.R
@@ -3,7 +3,7 @@ skip_on_cran()
 if (requireNamespace("sf", quietly = TRUE)) {
 
   test_that("fc utility functions work", {
-    file <- system.file("examples", "feature_collection.geojson", package = "geojsonio")
+    file <- example_sys_file("feature_collection.geojson")
     testfc <- st_read(file, quiet = TRUE)
     expect_equal(get_sf_column_name(testfc), "geometry")
 

--- a/tests/testthat/test-sf_classes.R
+++ b/tests/testthat/test-sf_classes.R
@@ -375,21 +375,21 @@ if (requireNamespace("sf", quietly = TRUE)) {
     expect_s3_class(geojson_json(pol_sf), "geojson")
     expect_equal(sf::read_sf(geojson_json(pol_sf))[["area"]], as.numeric(pol_sf$area))
   })
+  
+  test_that("geojson is valid with named sfc input", {
+    x <- sf::st_sfc(sf::st_point(0:1), sf::st_point(1:2))
+
+    names(x) <- 1:2
+
+    x_json <- geojson_json(x)
+
+    expect_equal(
+      unclass(x_json),
+      "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"Point\",\"coordinates\":[0,1]},{\"type\":\"Point\",\"coordinates\":[1,2]}]}",
+      ignore_attr = TRUE
+    )
+  })
 }
-
-test_that("geojson is valid with named sfc input", {
-  x <- sf::st_sfc(sf::st_point(0:1), sf::st_point(1:2))
-
-  names(x) <- 1:2
-
-  x_json <- geojson_json(x)
-
-  expect_equal(
-    unclass(x_json),
-    "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"Point\",\"coordinates\":[0,1]},{\"type\":\"Point\",\"coordinates\":[1,2]}]}",
-    ignore_attr = TRUE
-  )
-})
 
 ## Big test ------------------------------------------------------
 ## devtools::install_github("bcgov/bcmaps")

--- a/tests/testthat/test-sf_classes.R
+++ b/tests/testthat/test-sf_classes.R
@@ -8,8 +8,6 @@ un_class <- function(x) {
 
 if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
 
-  # suppressPackageStartupMessages(library(sf))
-
   file <- system.file("examples", "feature_collection.geojson", package = "geojsonio")
   testfc <- st_read(file, quiet = TRUE)
 

--- a/tests/testthat/test-sf_classes.R
+++ b/tests/testthat/test-sf_classes.R
@@ -345,8 +345,17 @@ if (requireNamespace("sf", quietly = TRUE)) {
     pt_xyzm <- sf::st_point(c(3, 4, 5, 6), dim = "XYZM")
 
     expect_equal(geojson_list(pt_xyz)$coordinates, c(3, 4, 5))
-    expect_equal(geojson_list(pt_xym)$coordinates, c(3, 4))
-    expect_equal(geojson_list(pt_xyzm)$coordinates, c(3, 4, 5))
+    expect_message(
+      expect_equal(
+        geojson_list(pt_xym)$coordinates,
+        c(3, 4)
+      ),
+      "removing M dimension as not supported in GeoJSON format"
+    )
+    expect_message(
+      expect_equal(geojson_list(pt_xyzm)$coordinates, c(3, 4, 5)),
+      "removing M dimension as not supported in GeoJSON format"
+    )
 
     p_list_xyzm <- lapply(list(c(3.2, 4, 5, 6), c(3, 4.6, 6, 7), c(3.8, 4.4, 7, 8)),
       sf::st_point,
@@ -365,7 +374,7 @@ if (requireNamespace("sf", quietly = TRUE)) {
     mp_sfc <- sf::st_sfc(mp_sfg)
     mp_sf <- sf::st_sf(x = "a", mp_sfc)
 
-    out <- geojson_list(mp_sf)
+    out <- supm(geojson_list(mp_sf))
     expect_equal(dim(out$features[[1]]$geometry$coordinates), c(6, 3))
   })
 

--- a/tests/testthat/test-sf_classes.R
+++ b/tests/testthat/test-sf_classes.R
@@ -1,17 +1,10 @@
 skip_on_cran()
 
-un_class <- function(x) {
-  x <- unclass(x)
-  attributes(x) <- NULL
-  return(x)
-}
-
 if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
 
-  file <- system.file("examples", "feature_collection.geojson", package = "geojsonio")
-  testfc <- st_read(file, quiet = TRUE)
-
   test_that("fc utility functions work", {
+    file <- system.file("examples", "feature_collection.geojson", package = "geojsonio")
+    testfc <- st_read(file, quiet = TRUE)
     expect_equal(get_sf_column_name(testfc), "geometry")
 
     expect_equal(get_geometry_type(testfc$geometry), "GEOMETRY")
@@ -59,18 +52,21 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
     pt_sf_json <- geojson_json(pt_sf)
 
     expect_equal(
-      un_class(pt_sfg_json),
-      "{\"type\":\"Point\",\"coordinates\":[3.2,4]}"
+      pt_sfg_json,
+      "{\"type\":\"Point\",\"coordinates\":[3.2,4]}",
+      ignore_attr = TRUE
     )
 
     expect_equal(
-      un_class(pt_sfc_json),
-      "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"Point\",\"coordinates\":[3.2,4]},{\"type\":\"Point\",\"coordinates\":[3,4.6]},{\"type\":\"Point\",\"coordinates\":[3.8,4.4]}]}"
+      pt_sfc_json,
+      "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"Point\",\"coordinates\":[3.2,4]},{\"type\":\"Point\",\"coordinates\":[3,4.6]},{\"type\":\"Point\",\"coordinates\":[3.8,4.4]}]}",
+      ignore_attr = TRUE
     )
 
     expect_equal(
-      un_class(pt_sf_json),
-      "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[3.2,4]}},{\"type\":\"Feature\",\"properties\":{\"x\":\"b\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[3,4.6]}},{\"type\":\"Feature\",\"properties\":{\"x\":\"c\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[3.8,4.4]}}]}"
+      pt_sf_json,
+      "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[3.2,4]}},{\"type\":\"Feature\",\"properties\":{\"x\":\"b\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[3,4.6]}},{\"type\":\"Feature\",\"properties\":{\"x\":\"c\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[3.8,4.4]}}]}",
+      ignore_attr = TRUE
     )
   })
 
@@ -100,18 +96,21 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
     expect_s3_class(mp_sf_json, "geojson")
 
     expect_equal(
-      un_class(mp_sfg_json),
-      "{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]}"
+      mp_sfg_json,
+      "{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]}",
+      ignore_attr = TRUE
     )
 
     expect_equal(
-      un_class(mp_sfc_json),
-      "{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]}"
+      mp_sfc_json,
+      "{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]}",
+      ignore_attr = TRUE
     )
 
     expect_equal(
-      un_class(mp_sf_json),
-      "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]}}]}"
+      mp_sf_json,
+      "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]}}]}",
+      ignore_attr = TRUE
     )
   })
 
@@ -142,18 +141,21 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
     expect_s3_class(pol_sf_json, "geojson")
 
     expect_equal(
-      un_class(pol_sfg_json),
-      "{\"type\":\"Polygon\",\"coordinates\":[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]]}"
+      pol_sfg_json,
+      "{\"type\":\"Polygon\",\"coordinates\":[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]]}",
+      ignore_attr = TRUE
     )
 
     expect_equal(
-      un_class(pol_sfc_json),
-      "{\"type\":\"Polygon\",\"coordinates\":[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]]}"
+      pol_sfc_json,
+      "{\"type\":\"Polygon\",\"coordinates\":[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]]}",
+      ignore_attr = TRUE
     )
 
     expect_equal(
-      un_class(pol_sf_json),
-      "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]]}}]}"
+      pol_sf_json,
+      "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]]}}]}",
+      ignore_attr = TRUE
     )
   })
 
@@ -185,18 +187,21 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
     expect_s3_class(mpol_sf_json, "geojson")
 
     expect_equal(
-      un_class(mpol_sfg_json),
-      "{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]}"
+      mpol_sfg_json,
+      "{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]}",
+      ignore_attr = TRUE
     )
 
     expect_equal(
-      un_class(mpol_sfc_json),
-      "{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]}"
+      mpol_sfc_json,
+      "{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]}",
+      ignore_attr = TRUE
     )
 
     expect_equal(
-      un_class(mpol_sf_json),
-      "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]}}]}"
+      mpol_sf_json,
+      "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]}}]}",
+      ignore_attr = TRUE
     )
   })
 
@@ -228,18 +233,21 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
     expect_s3_class(ls_sf_json, "geojson")
 
     expect_equal(
-      un_class(ls_sfg_json),
-      "{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}"
+      ls_sfg_json,
+      "{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}",
+      ignore_attr = TRUE
     )
 
     expect_equal(
-      un_class(ls_sfc_json),
-      "{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}"
+      ls_sfc_json,
+      "{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}",
+      ignore_attr = TRUE
     )
 
     expect_equal(
-      un_class(ls_sf_json),
-      "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}}]}"
+      ls_sf_json,
+      "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}}]}",
+      ignore_attr = TRUE
     )
   })
 
@@ -270,18 +278,21 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
     expect_s3_class(mls_sf_json, "geojson")
 
     expect_equal(
-      un_class(mls_sfg_json),
-      "{\"type\":\"MultiLineString\",\"coordinates\":[[[0,3],[0,4],[1,5],[2,5]],[[0.2,3],[0.2,4],[1,4.8],[2,4.8]],[[0,4.4],[0.6,5]]]}"
+      mls_sfg_json,
+      "{\"type\":\"MultiLineString\",\"coordinates\":[[[0,3],[0,4],[1,5],[2,5]],[[0.2,3],[0.2,4],[1,4.8],[2,4.8]],[[0,4.4],[0.6,5]]]}",
+      ignore_attr = TRUE
     )
 
     expect_equal(
-      un_class(mls_sfc_json),
-      "{\"type\":\"MultiLineString\",\"coordinates\":[[[0,3],[0,4],[1,5],[2,5]],[[0.2,3],[0.2,4],[1,4.8],[2,4.8]],[[0,4.4],[0.6,5]]]}"
+      mls_sfc_json,
+      "{\"type\":\"MultiLineString\",\"coordinates\":[[[0,3],[0,4],[1,5],[2,5]],[[0.2,3],[0.2,4],[1,4.8],[2,4.8]],[[0,4.4],[0.6,5]]]}",
+      ignore_attr = TRUE
     )
 
     expect_equal(
-      un_class(mls_sf_json),
-      "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"MultiLineString\",\"coordinates\":[[[0,3],[0,4],[1,5],[2,5]],[[0.2,3],[0.2,4],[1,4.8],[2,4.8]],[[0,4.4],[0.6,5]]]}}]}"
+      mls_sf_json,
+      "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"MultiLineString\",\"coordinates\":[[[0,3],[0,4],[1,5],[2,5]],[[0.2,3],[0.2,4],[1,4.8],[2,4.8]],[[0,4.4],[0.6,5]]]}}]}",
+      ignore_attr = TRUE
     )
   })
 
@@ -310,18 +321,21 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
     expect_s3_class(gc_sf_json, "geojson")
 
     expect_equal(
-      un_class(gc_sfg_json),
-      "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]},{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]},{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}]}"
+      gc_sfg_json,
+      "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]},{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]},{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}]}",
+      ignore_attr = TRUE
     )
 
     expect_equal(
-      un_class(gc_sfc_json),
-      "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]},{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]},{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}]}"
+      gc_sfc_json,
+      "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]},{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]},{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}]}",
+      ignore_attr = TRUE
     )
 
     expect_equal(
-      un_class(gc_sf_json),
-      "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]},{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]},{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}]}}]}"
+      gc_sf_json,
+      "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"x\":\"a\"},\"geometry\":{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"MultiPoint\",\"coordinates\":[[3.2,4],[3,4.6],[3.8,4.4],[3.5,3.8],[3.4,3.6],[3.9,4.5]]},{\"type\":\"MultiPolygon\",\"coordinates\":[[[[0,0],[1,0],[3,2],[2,4],[1,4],[0,0]],[[1,1],[1,2],[2,2],[1,1]]],[[[3,0],[4,0],[4,1],[3,1],[3,0]],[[3.3,0.3],[3.3,0.8],[3.8,0.8],[3.8,0.3],[3.3,0.3]]],[[[3,3],[4,2],[4,3],[3,3]]]]},{\"type\":\"LineString\",\"coordinates\":[[0,3],[0,4],[1,5],[2,5]]}]}}]}",
+      ignore_attr = TRUE
     )
   })
 

--- a/tests/testthat/test-sf_classes.R
+++ b/tests/testthat/test-sf_classes.R
@@ -1,6 +1,6 @@
 skip_on_cran()
 
-if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
+if (requireNamespace("sf", quietly = TRUE)) {
 
   test_that("fc utility functions work", {
     file <- system.file("examples", "feature_collection.geojson", package = "geojsonio")
@@ -12,9 +12,9 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
   })
 
   ## POINT
-  p_list <- lapply(list(c(3.2, 4), c(3, 4.6), c(3.8, 4.4)), st_point)
-  pt_sfc <- st_sfc(p_list)
-  pt_sf <- st_sf(x = c("a", "b", "c"), pt_sfc)
+  p_list <- lapply(list(c(3.2, 4), c(3, 4.6), c(3.8, 4.4)), sf::st_point)
+  pt_sfc <- sf::st_sfc(p_list)
+  pt_sf <- sf::st_sf(x = c("a", "b", "c"), pt_sfc)
 
   test_that("geojson_list works with points", {
     point_sfg_list <- geojson_list(pt_sfc[[1]])
@@ -72,9 +72,9 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
 
   # ## MULTIPOINT
   p <- rbind(c(3.2, 4), c(3, 4.6), c(3.8, 4.4), c(3.5, 3.8), c(3.4, 3.6), c(3.9, 4.5))
-  mp_sfg <- st_multipoint(p)
-  mp_sfc <- st_sfc(mp_sfg)
-  mp_sf <- st_sf(x = "a", mp_sfc)
+  mp_sfg <- sf::st_multipoint(p)
+  mp_sfc <- sf::st_sfc(mp_sfg)
+  mp_sf <- sf::st_sf(x = "a", mp_sfc)
 
   test_that("geojson_list works with multipoints", {
     mp_sfg_list <- geojson_list(mp_sfg)
@@ -117,9 +117,9 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
   ## POLYGON
   p1 <- rbind(c(0, 0), c(1, 0), c(3, 2), c(2, 4), c(1, 4), c(0, 0))
   p2 <- rbind(c(1, 1), c(1, 2), c(2, 2), c(1, 1))
-  pol_sfg <- st_polygon(list(p1, p2))
-  pol_sfc <- st_sfc(pol_sfg)
-  pol_sf <- st_sf(x = "a", pol_sfc)
+  pol_sfg <- sf::st_polygon(list(p1, p2))
+  pol_sfc <- sf::st_sfc(pol_sfg)
+  pol_sf <- sf::st_sf(x = "a", pol_sfc)
 
   test_that("geojson_list works with polygons", {
     pol_sfg_list <- geojson_list(pol_sfg)
@@ -163,9 +163,9 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
   p3 <- rbind(c(3, 0), c(4, 0), c(4, 1), c(3, 1), c(3, 0))
   p4 <- rbind(c(3.3, 0.3), c(3.8, 0.3), c(3.8, 0.8), c(3.3, 0.8), c(3.3, 0.3))[5:1, ]
   p5 <- rbind(c(3, 3), c(4, 2), c(4, 3), c(3, 3))
-  mpol_sfg <- st_multipolygon(list(list(p1, p2), list(p3, p4), list(p5)))
-  mpol_sfc <- st_sfc(mpol_sfg)
-  mpol_sf <- st_sf(x = "a", mpol_sfc)
+  mpol_sfg <- sf::st_multipolygon(list(list(p1, p2), list(p3, p4), list(p5)))
+  mpol_sfc <- sf::st_sfc(mpol_sfg)
+  mpol_sf <- sf::st_sf(x = "a", mpol_sfc)
 
   test_that("geojson_list works with multipolygons", {
     mpol_sfg_list <- geojson_list(mpol_sfg)
@@ -209,9 +209,9 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
 
   ## LINESTRING
   s1 <- rbind(c(0, 3), c(0, 4), c(1, 5), c(2, 5))
-  ls_sfg <- st_linestring(s1)
-  ls_sfc <- st_sfc(ls_sfg)
-  ls_sf <- st_sf(x = "a", ls_sfc)
+  ls_sfg <- sf::st_linestring(s1)
+  ls_sfc <- sf::st_sfc(ls_sfg)
+  ls_sf <- sf::st_sf(x = "a", ls_sfc)
 
   test_that("geojson_list works with linestrings", {
     ls_sfg_list <- geojson_list(ls_sfg)
@@ -254,9 +254,9 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
   ## MULTILINESTRING
   s2 <- rbind(c(0.2, 3), c(0.2, 4), c(1, 4.8), c(2, 4.8))
   s3 <- rbind(c(0, 4.4), c(0.6, 5))
-  mls_sfg <- st_multilinestring(list(s1, s2, s3))
-  mls_sfc <- st_sfc(mls_sfg)
-  mls_sf <- st_sf(x = "a", mls_sfc)
+  mls_sfg <- sf::st_multilinestring(list(s1, s2, s3))
+  mls_sfc <- sf::st_sfc(mls_sfg)
+  mls_sf <- sf::st_sf(x = "a", mls_sfc)
 
   test_that("geojson_list works with multilinestrings", {
     mls_sfg_list <- geojson_list(ls_sfg)
@@ -297,9 +297,9 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
   })
 
   # ## GEOMETRYCOLLECTION
-  gc_sfg <- st_geometrycollection(list(mp_sfg, mpol_sfg, ls_sfg))
-  gc_sfc <- st_sfc(gc_sfg)
-  gc_sf <- st_sf(x = "a", gc_sfc)
+  gc_sfg <- sf::st_geometrycollection(list(mp_sfg, mpol_sfg, ls_sfg))
+  gc_sfc <- sf::st_sfc(gc_sfg)
+  gc_sf <- sf::st_sf(x = "a", gc_sfc)
 
   test_that("geojson_list works with geometry collections", {
     gc_sfg_list <- geojson_list(gc_sfg)
@@ -340,20 +340,20 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
   })
 
   test_that("Deals with Z and M dimensions: points", {
-    pt_xyz <- st_point(c(3, 4, 5), dim = "XYZ")
-    pt_xym <- st_point(c(3, 4, 5), dim = "XYM")
-    pt_xyzm <- st_point(c(3, 4, 5, 6), dim = "XYZM")
+    pt_xyz <- sf::st_point(c(3, 4, 5), dim = "XYZ")
+    pt_xym <- sf::st_point(c(3, 4, 5), dim = "XYM")
+    pt_xyzm <- sf::st_point(c(3, 4, 5, 6), dim = "XYZM")
 
     expect_equal(geojson_list(pt_xyz)$coordinates, c(3, 4, 5))
     expect_equal(geojson_list(pt_xym)$coordinates, c(3, 4))
     expect_equal(geojson_list(pt_xyzm)$coordinates, c(3, 4, 5))
 
     p_list_xyzm <- lapply(list(c(3.2, 4, 5, 6), c(3, 4.6, 6, 7), c(3.8, 4.4, 7, 8)),
-      st_point,
+      sf::st_point,
       dim = "XYZM"
     )
-    pt_sfc_xyzm <- st_sfc(p_list_xyzm)
-    pt_sf_xyzm <- st_sf(x = c("a", "b", "c"), pt_sfc_xyzm)
+    pt_sfc_xyzm <- sf::st_sfc(p_list_xyzm)
+    pt_sf_xyzm <- sf::st_sf(x = c("a", "b", "c"), pt_sfc_xyzm)
   })
 
   test_that("Deal with M dimensions: multipoint", {
@@ -361,9 +361,9 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
       c(3.2, 4, 5, 6), c(3, 4.6, 7, 8), c(3.8, 4.4, 9, 10),
       c(3.5, 3.8, 11, 12), c(3.4, 3.6, 13, 14), c(3.9, 4.5, 15, 16)
     )
-    mp_sfg <- st_multipoint(p, dim = "XYZM")
-    mp_sfc <- st_sfc(mp_sfg)
-    mp_sf <- st_sf(x = "a", mp_sfc)
+    mp_sfg <- sf::st_multipoint(p, dim = "XYZM")
+    mp_sfc <- sf::st_sfc(mp_sfg)
+    mp_sf <- sf::st_sf(x = "a", mp_sfc)
 
     out <- geojson_list(mp_sf)
     expect_equal(dim(out$features[[1]]$geometry$coordinates), c(6, 3))
@@ -373,12 +373,12 @@ if (suppressPackageStartupMessages(require("sf", quietly = TRUE))) {
     pol_sf$area <- structure(rep(1, nrow(pol_sf)), class = "units")
 
     expect_s3_class(geojson_json(pol_sf), "geojson")
-    expect_equal(read_sf(geojson_json(pol_sf))[["area"]], as.numeric(pol_sf$area))
+    expect_equal(sf::read_sf(geojson_json(pol_sf))[["area"]], as.numeric(pol_sf$area))
   })
 }
 
 test_that("geojson is valid with named sfc input", {
-  x <- st_sfc(st_point(0:1), st_point(1:2))
+  x <- sf::st_sfc(sf::st_point(0:1), sf::st_point(1:2))
 
   names(x) <- 1:2
 
@@ -394,7 +394,7 @@ test_that("geojson is valid with named sfc input", {
 ## Big test ------------------------------------------------------
 ## devtools::install_github("bcgov/bcmaps")
 # library(bcmaps)
-# eco_sf <- st_as_sf(ecoprovinces)
-# eco_sf <- st_transform(eco_sf, 4326)
+# eco_sf <- sf::st_as_sf(ecoprovinces)
+# eco_sf <- sf::st_transform(eco_sf, 4326)
 # eco_geojson <- geojson_json(eco_sf)
 # map_gist(eco_geojson)

--- a/tests/testthat/test-spatial_methods.R
+++ b/tests/testthat/test-spatial_methods.R
@@ -25,7 +25,7 @@ test_that("SpatialLines to SpatialLinesDataFrame", {
 
 test_that("SpatialPixels to SpatialPointsDataFrame", {
   skip_on_cran()
-  sp_pixels <- suppressWarnings(SpatialPixels(SpatialPoints(us_cities[c("long", "lat")])))
+  sp_pixels <- supw(SpatialPixels(SpatialPoints(us_cities[c("long", "lat")])))
   a <- as(sp_pixels, "SpatialPointsDataFrame")
 
   expect_s4_class(sp_pixels, "SpatialPixels")

--- a/tests/testthat/test-spatial_methods.R
+++ b/tests/testthat/test-spatial_methods.R
@@ -1,7 +1,5 @@
 skip_on_cran()
 
-suppressPackageStartupMessages(library("sp"))
-
 sp_poly <- local({
   poly1 <- Polygons(list(Polygon(cbind(
     c(-100, -90, -85, -100),

--- a/tests/testthat/test-spatial_methods.R
+++ b/tests/testthat/test-spatial_methods.R
@@ -1,10 +1,9 @@
 test_that("SpatialPoints to SpatialPointsDataFrame", {
   skip_on_cran()
-  sp_pts <- local({
-    a <- c(1, 2, 3, 4, 5)
-    b <- c(3, 2, 5, 1, 4)
-    SpatialPoints(cbind(a, b))
-  })
+  sp_pts <- SpatialPoints(cbind(
+    c(1, 2, 3, 4, 5),
+    c(3, 2, 5, 1, 4)
+  ))
   a <- as(sp_pts, "SpatialPointsDataFrame")
 
   expect_s4_class(sp_pts, "SpatialPoints")
@@ -13,12 +12,11 @@ test_that("SpatialPoints to SpatialPointsDataFrame", {
 
 test_that("SpatialLines to SpatialLinesDataFrame", {
   skip_on_cran()
-  sp_lines <- local({
-    c1 <- cbind(c(1, 2, 3), c(3, 2, 2))
-    L1 <- Line(c1)
-    Ls1 <- Lines(list(L1), ID = "a")
-    SpatialLines(list(Ls1))
-  })
+
+  c1 <- cbind(c(1, 2, 3), c(3, 2, 2))
+  L1 <- Line(c1)
+  Ls1 <- Lines(list(L1), ID = "a")
+  sp_lines <- SpatialLines(list(Ls1))
   a <- as(sp_lines, "SpatialLinesDataFrame")
 
   expect_s4_class(sp_lines, "SpatialLines")

--- a/tests/testthat/test-spatial_methods.R
+++ b/tests/testthat/test-spatial_methods.R
@@ -1,41 +1,10 @@
-skip_on_cran()
-
-sp_poly <- local({
-  poly1 <- Polygons(list(Polygon(cbind(
-    c(-100, -90, -85, -100),
-    c(40, 50, 45, 40)
-  ))), "1")
-  poly2 <- Polygons(list(Polygon(cbind(
-    c(-90, -80, -75, -90),
-    c(30, 40, 35, 30)
-  ))), "2")
-  SpatialPolygons(list(poly1, poly2), 1:2)
-})
-
-sp_pts <- local({
-  a <- c(1, 2, 3, 4, 5)
-  b <- c(3, 2, 5, 1, 4)
-  SpatialPoints(cbind(a, b))
-})
-
-sp_lines <- local({
-  c1 <- cbind(c(1, 2, 3), c(3, 2, 2))
-  L1 <- Line(c1)
-  Ls1 <- Lines(list(L1), ID = "a")
-  SpatialLines(list(Ls1))
-})
-
-sp_grid <- local({
-  x <- GridTopology(c(0, 0), c(1, 1), c(5, 5))
-  SpatialGrid(x)
-})
-
-sp_pixels <- local({
-  suppressWarnings(SpatialPixels(SpatialPoints(us_cities[c("long", "lat")])))
-})
-
-
 test_that("SpatialPoints to SpatialPointsDataFrame", {
+  skip_on_cran()
+  sp_pts <- local({
+    a <- c(1, 2, 3, 4, 5)
+    b <- c(3, 2, 5, 1, 4)
+    SpatialPoints(cbind(a, b))
+  })
   a <- as(sp_pts, "SpatialPointsDataFrame")
 
   expect_s4_class(sp_pts, "SpatialPoints")
@@ -43,6 +12,13 @@ test_that("SpatialPoints to SpatialPointsDataFrame", {
 })
 
 test_that("SpatialLines to SpatialLinesDataFrame", {
+  skip_on_cran()
+  sp_lines <- local({
+    c1 <- cbind(c(1, 2, 3), c(3, 2, 2))
+    L1 <- Line(c1)
+    Ls1 <- Lines(list(L1), ID = "a")
+    SpatialLines(list(Ls1))
+  })
   a <- as(sp_lines, "SpatialLinesDataFrame")
 
   expect_s4_class(sp_lines, "SpatialLines")
@@ -50,6 +26,8 @@ test_that("SpatialLines to SpatialLinesDataFrame", {
 })
 
 test_that("SpatialPixels to SpatialPointsDataFrame", {
+  skip_on_cran()
+  sp_pixels <- suppressWarnings(SpatialPixels(SpatialPoints(us_cities[c("long", "lat")])))
   a <- as(sp_pixels, "SpatialPointsDataFrame")
 
   expect_s4_class(sp_pixels, "SpatialPixels")

--- a/tests/testthat/test-topojson_read.R
+++ b/tests/testthat/test-topojson_read.R
@@ -1,7 +1,7 @@
 test_that("topojson_read works with file inputs", {
   skip_on_cran()
 
-  file <- system.file("examples", "us_states.topojson", package = "geojsonio")
+  file <- example_sys_file("us_states.topojson")
   aa <- topojson_read(file, stringsAsFactors = TRUE)
   df <- as.data.frame(aa)
 
@@ -16,7 +16,7 @@ test_that("topojson_read works with file inputs", {
 test_that("topojson_read works with file inputs: stringsAsFactors works", {
   skip_on_cran()
 
-  file <- system.file("examples", "us_states.topojson", package = "geojsonio")
+  file <- example_sys_file("us_states.topojson")
   aa <- topojson_read(file, stringsAsFactors = FALSE)
   df <- as.data.frame(aa)
   expect_type(df$id, "character")
@@ -37,7 +37,7 @@ test_that("topojson_read works with url inputs", {
 test_that("topojson_read works with as.location inputs", {
   skip_on_cran()
 
-  file <- system.file("examples", "us_states.topojson", package = "geojsonio")
+  file <- example_sys_file("us_states.topojson")
   aa <- topojson_read(as.location(file))
   df <- as.data.frame(aa)
 

--- a/tests/testthat/test-topojson_read.R
+++ b/tests/testthat/test-topojson_read.R
@@ -48,7 +48,7 @@ test_that("topojson_read works with as.location inputs", {
 test_that("topojson_read works with .json extension", {
   skip_on_cran()
 
-  file <- tempfile(fileext = ".json")
+  file <- withr::local_tempfile(fileext = ".json")
   cat('{"type":"Topology","objects":{"foo":{"type":"LineString","arcs":[0]}},"arcs":[[[100,0],[101,1]]],"bbox":[100,0,101,1]}',
     file = file
   )

--- a/tests/testthat/test-topojson_write.R
+++ b/tests/testthat/test-topojson_write.R
@@ -12,7 +12,7 @@ test_that("topojson_write temporarily removed", {
 #             c(-106.61132812499999,43.45291889355468),
 #             c(-106.61132812499999,39.436192999314095),
 #             c(-114.345703125,39.436192999314095))
-#   gwf1 <- tempfile(fileext = ".topojson")
+#   gwf1 <- withr::local_tempfile(fileext = ".topojson")
 #   a <- supw(suppressMessages(topojson_write(poly, geometry = "polygon", file = gwf1)))
 #   expect_s3_class(a, "topojson_file")
 #   a_txt <- gsub("\\s+", " ", paste0(readLines(gwf1), collapse = ""))
@@ -21,7 +21,7 @@ test_that("topojson_write temporarily removed", {
 #     "{\"type\":\"Topology\",\"objects\":{\"foo\":{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"Polygon\",\"arcs\":[[0]],\"properties\":{\"dummy\":0}}]}},\"arcs\":[[[-114.345703125,39.436192999314095],[-114.345703125,43.45291889355468],[-106.61132812499999,43.45291889355468],[-106.61132812499999,39.436192999314095],[-114.345703125,39.436192999314095]]],\"bbox\":[-114.345703125,39.436192999314095,-106.61132812499999,43.45291889355468]}"
 #   )
 
-#   gwf2 <- tempfile(fileext = ".topojson")
+#   gwf2 <- withr::local_tempfile(fileext = ".topojson")
 #   b <- supw(suppressMessages(topojson_write(poly, geometry = "polygon", precision = 2, file = gwf2)))
 #   expect_s3_class(b, "topojson_file")
 #   b_txt <- gsub("\\s+", " ", paste0(readLines(gwf2), collapse = ""))
@@ -35,7 +35,7 @@ test_that("topojson_write temporarily removed", {
 #   skip_on_travis()
 #   skip_on_cran()
 
-#   gwf3 <- tempfile(fileext = ".topojson")
+#   gwf3 <- withr::local_tempfile(fileext = ".topojson")
 #   cc <- suppressMessages(topojson_write(us_cities[1:2,], lat = 'lat', lon = 'long', precision = 2, file = gwf3))
 #   expect_s3_class(cc, "topojson_file")
 #   cc_txt <- gsub("\\s+", " ", paste0(readLines(gwf3), collapse = ""))
@@ -44,7 +44,7 @@ test_that("topojson_write temporarily removed", {
 #     "{\"type\":\"Topology\",\"objects\":{\"foo\":{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"Point\",\"coordinates\":[-99.74,32.45],\"properties\":{\"name\":\"Abilene TX\",\"country.etc\":\"TX\",\"pop\":113888,\"lat\":32.45,\"long\":-99.74,\"capital\":0}},{\"type\":\"Point\",\"coordinates\":[-81.52,41.08],\"properties\":{\"name\":\"Akron OH\",\"country.etc\":\"OH\",\"pop\":206634,\"lat\":41.08,\"long\":-81.52,\"capital\":0}}]}},\"arcs\":[],\"bbox\":[-99.74,32.45,-81.52,41.08]}"
 #   )
 
-#   gwf4 <- tempfile(fileext = ".topojson")
+#   gwf4 <- withr::local_tempfile(fileext = ".topojson")
 #   d <- suppressMessages(topojson_write(us_cities[1:2,], lat = 'lat', lon = 'long', precision = 1, file = gwf4))
 #   expect_s3_class(d, "topojson_file")
 #   d_txt <- gsub("\\s+", " ", paste0(readLines(gwf4), collapse = ""))
@@ -64,13 +64,13 @@ test_that("topojson_write temporarily removed", {
 #                                        c(30.111,40.111,35.111,30.111)))), "2")
 #   sp_poly <- SpatialPolygons(list(poly1, poly2), 1:2)
 
-#   gwf5 <- tempfile(fileext = ".topojson")
+#   gwf5 <- withr::local_tempfile(fileext = ".topojson")
 #   e <- suppressMessages(topojson_write(sp_poly, file = gwf5))
 #   expect_s3_class(e, "topojson_file")
 #   e_txt <- gsub("\\s+", " ", paste0(readLines(gwf5), collapse = ""))
 #   expect_equal(e_txt, "{\"type\":\"Topology\",\"objects\":{\"foo\":{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"Polygon\",\"arcs\":[[0]],\"properties\":{\"dummy\":0}},{\"type\":\"Polygon\",\"arcs\":[[1]],\"properties\":{\"dummy\":0}}]}},\"arcs\":[[[-100.111,40.111],[-90.111,50.111],[-85.111,45.111],[-100.111,40.111]],[[-90.111,30.111],[-80.111,40.111],[-75.111,35.111],[-90.111,30.111]]],\"bbox\":[-100.111,30.111,-75.111,50.111]}")
 
-#   gwf6 <- tempfile(fileext = ".topojson")
+#   gwf6 <- withr::local_tempfile(fileext = ".topojson")
 #   f <- suppressMessages(topojson_write(sp_poly, precision = 2, file = gwf6))
 #   expect_s3_class(f, "topojson_file")
 #   f_txt <- gsub("\\s+", " ", paste0(readLines(gwf6), collapse = ""))
@@ -82,7 +82,7 @@ test_that("topojson_write temporarily removed", {
 #   bad <- list(c(100.0,0.0), c(101.0,0.0), c(101.0,1.0), c(100.0,1.0), c(100.0,1))
 
 #   # fine
-#   gwf7 <- tempfile(fileext = ".topojson")
+#   gwf7 <- withr::local_tempfile(fileext = ".topojson")
 #   fine <- supw(suppressMessages(topojson_write(good, geometry = "polygon", file = gwf7)))
 #   expect_s3_class(fine, "topojson_file")
 #   expect_type(fine[[1]], "character")
@@ -102,7 +102,7 @@ test_that("topojson_write temporarily removed", {
 #   spdf <- SpatialPolygonsDataFrame(SpatialPolygons(list(poly1), 1L),
 #                                    data.frame(a = structure(1.5, class = "units"),
 #                                               b = ordered("z")))
-#   gwf8 <- tempfile(fileext = ".topojson")
+#   gwf8 <- withr::local_tempfile(fileext = ".topojson")
 #   expect_s3_class(topojson_write(spdf, file = gwf8), "topojson_file")
 #   spdf2 <- as(sf::st_read(gwf8, quiet = TRUE, stringsAsFactors = FALSE), "Spatial")
 #   expect_type(spdf2@data$a, "double")
@@ -111,7 +111,7 @@ test_that("topojson_write temporarily removed", {
 
 # test_that("topojson_write works with different object name", {
 #   vec <- c(-99.74, 32.45)
-#   gwf9 <- tempfile(fileext = ".topojson")
+#   gwf9 <- withr::local_tempfile(fileext = ".topojson")
 #   x <- topojson_write(vec, file = gwf9, object_name = "California")
 #   expect_s3_class(x, "topojson_file")
 #   expect_true(grepl("California", readLines(gwf9)))
@@ -124,7 +124,7 @@ test_that("topojson_write temporarily removed", {
 
 # test_that("topojson_write works with quantization > 0", {
 #   vec <- c(-99.74, 32.45)
-#   gwf9 <- tempfile(fileext = ".topojson")
+#   gwf9 <- withr::local_tempfile(fileext = ".topojson")
 #   x <- topojson_write(vec, file = gwf9, quantization = 1e4)
 #   expect_s3_class(x, "topojson_file")
 #   expect_true(grepl("transform", readLines(gwf9)))

--- a/tests/testthat/test-topojson_write.R
+++ b/tests/testthat/test-topojson_write.R
@@ -13,7 +13,7 @@ test_that("topojson_write temporarily removed", {
 #             c(-106.61132812499999,39.436192999314095),
 #             c(-114.345703125,39.436192999314095))
 #   gwf1 <- withr::local_tempfile(fileext = ".topojson")
-#   a <- supw(suppressMessages(topojson_write(poly, geometry = "polygon", file = gwf1)))
+#   a <- supw(supm(topojson_write(poly, geometry = "polygon", file = gwf1)))
 #   expect_s3_class(a, "topojson_file")
 #   a_txt <- gsub("\\s+", " ", paste0(readLines(gwf1), collapse = ""))
 #   expect_equal(
@@ -22,7 +22,7 @@ test_that("topojson_write temporarily removed", {
 #   )
 
 #   gwf2 <- withr::local_tempfile(fileext = ".topojson")
-#   b <- supw(suppressMessages(topojson_write(poly, geometry = "polygon", precision = 2, file = gwf2)))
+#   b <- supw(supm(topojson_write(poly, geometry = "polygon", precision = 2, file = gwf2)))
 #   expect_s3_class(b, "topojson_file")
 #   b_txt <- gsub("\\s+", " ", paste0(readLines(gwf2), collapse = ""))
 #   expect_equal(
@@ -36,7 +36,7 @@ test_that("topojson_write temporarily removed", {
 #   skip_on_cran()
 
 #   gwf3 <- withr::local_tempfile(fileext = ".topojson")
-#   cc <- suppressMessages(topojson_write(us_cities[1:2,], lat = 'lat', lon = 'long', precision = 2, file = gwf3))
+#   cc <- supm(topojson_write(us_cities[1:2,], lat = 'lat', lon = 'long', precision = 2, file = gwf3))
 #   expect_s3_class(cc, "topojson_file")
 #   cc_txt <- gsub("\\s+", " ", paste0(readLines(gwf3), collapse = ""))
 #   expect_equal(
@@ -45,7 +45,7 @@ test_that("topojson_write temporarily removed", {
 #   )
 
 #   gwf4 <- withr::local_tempfile(fileext = ".topojson")
-#   d <- suppressMessages(topojson_write(us_cities[1:2,], lat = 'lat', lon = 'long', precision = 1, file = gwf4))
+#   d <- supm(topojson_write(us_cities[1:2,], lat = 'lat', lon = 'long', precision = 1, file = gwf4))
 #   expect_s3_class(d, "topojson_file")
 #   d_txt <- gsub("\\s+", " ", paste0(readLines(gwf4), collapse = ""))
 #   expect_equal(
@@ -65,13 +65,13 @@ test_that("topojson_write temporarily removed", {
 #   sp_poly <- SpatialPolygons(list(poly1, poly2), 1:2)
 
 #   gwf5 <- withr::local_tempfile(fileext = ".topojson")
-#   e <- suppressMessages(topojson_write(sp_poly, file = gwf5))
+#   e <- supm(topojson_write(sp_poly, file = gwf5))
 #   expect_s3_class(e, "topojson_file")
 #   e_txt <- gsub("\\s+", " ", paste0(readLines(gwf5), collapse = ""))
 #   expect_equal(e_txt, "{\"type\":\"Topology\",\"objects\":{\"foo\":{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"Polygon\",\"arcs\":[[0]],\"properties\":{\"dummy\":0}},{\"type\":\"Polygon\",\"arcs\":[[1]],\"properties\":{\"dummy\":0}}]}},\"arcs\":[[[-100.111,40.111],[-90.111,50.111],[-85.111,45.111],[-100.111,40.111]],[[-90.111,30.111],[-80.111,40.111],[-75.111,35.111],[-90.111,30.111]]],\"bbox\":[-100.111,30.111,-75.111,50.111]}")
 
 #   gwf6 <- withr::local_tempfile(fileext = ".topojson")
-#   f <- suppressMessages(topojson_write(sp_poly, precision = 2, file = gwf6))
+#   f <- supm(topojson_write(sp_poly, precision = 2, file = gwf6))
 #   expect_s3_class(f, "topojson_file")
 #   f_txt <- gsub("\\s+", " ", paste0(readLines(gwf6), collapse = ""))
 #   expect_equal(f_txt, "{\"type\":\"Topology\",\"objects\":{\"foo\":{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"Polygon\",\"arcs\":[[0]],\"properties\":{\"dummy\":0}},{\"type\":\"Polygon\",\"arcs\":[[1]],\"properties\":{\"dummy\":0}}]}},\"arcs\":[[[-100.11,40.11],[-90.11,50.11],[-85.11,45.11],[-100.11,40.11]],[[-90.11,30.11],[-80.11,40.11],[-75.11,35.11],[-90.11,30.11]]],\"bbox\":[-100.11,30.11,-75.11,50.11]}")
@@ -83,7 +83,7 @@ test_that("topojson_write temporarily removed", {
 
 #   # fine
 #   gwf7 <- withr::local_tempfile(fileext = ".topojson")
-#   fine <- supw(suppressMessages(topojson_write(good, geometry = "polygon", file = gwf7)))
+#   fine <- supw(supm(topojson_write(good, geometry = "polygon", file = gwf7)))
 #   expect_s3_class(fine, "topojson_file")
 #   expect_type(fine[[1]], "character")
 
@@ -92,7 +92,7 @@ test_that("topojson_write temporarily removed", {
 #                "First and last point in a polygon must be identical")
 
 #   # doesn't matter if geometry != polygon
-#   expect_s3_class(suppressMessages(topojson_write(bad)), "topojson_file")
+#   expect_s3_class(supm(topojson_write(bad)), "topojson_file")
 # })
 
 # test_that("topojson_write unclasses columns with special classes so writeOGR works", {

--- a/tests/testthat/test-topojson_write.R
+++ b/tests/testthat/test-topojson_write.R
@@ -58,7 +58,6 @@ test_that("topojson_write temporarily removed", {
 #   skip_on_travis()
 #   skip_on_cran()
 
-#   library('sp')
 #   poly1 <- Polygons(list(Polygon(cbind(c(-100.111,-90.111,-85.111,-100.111),
 #                                        c(40.111,50.111,45.111,40.111)))), "1")
 #   poly2 <- Polygons(list(Polygon(cbind(c(-90.111,-80.111,-75.111,-90.111),
@@ -97,8 +96,6 @@ test_that("topojson_write temporarily removed", {
 # })
 
 # test_that("topojson_write unclasses columns with special classes so writeOGR works", {
-#   library('sp')
-#   library('sf')
 
 #   poly1 <- Polygons(list(Polygon(cbind(c(-100,-90,-85,-100),
 #                                        c(40,50,45,40)))), "1")

--- a/tests/testthat/test-topojson_write.R
+++ b/tests/testthat/test-topojson_write.R
@@ -96,7 +96,7 @@ test_that("topojson_write temporarily removed", {
 # })
 
 # test_that("topojson_write unclasses columns with special classes so writeOGR works", {
-
+#   skip_if_not_installed("sf")
 #   poly1 <- Polygons(list(Polygon(cbind(c(-100,-90,-85,-100),
 #                                        c(40,50,45,40)))), "1")
 #   spdf <- SpatialPolygonsDataFrame(SpatialPolygons(list(poly1), 1L),


### PR DESCRIPTION
Try to follow newer best practices, mostly related to https://testthat.r-lib.org/articles/test-fixtures.html 

## Description
The changes are across these general themes:
- each test should be a self contained unit and clean up after itself in the safest and most-cran compatible way
  - setup code is either in helper file or within test
  - running the test should not change landscape (no library or require)
- silence informational messages during test run

Note that to run tests interactively, `devtools::load_all()` is needed, which also loads helper files

I added one suggested dependency: withr which is used in tests. I believe that it is a relatively light and stable dependency, but adds safety to cleanups.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

Closes #188 
