### PR TITLE
Update roxygen2 from CRAN email

### DIFF
--- a/R/geojsonio-package.r
+++ b/R/geojsonio-package.r
@@ -49,8 +49,7 @@
 #' @author Scott Chamberlain
 #' @author Andy Teucher \email{andy.teucher@@gmail.com}
 #' @author Michael Mahoney \email{mike.mahoney.218@@gmail.com}
-#' @docType package
-NULL
+"_PACKAGE"
 
 #' This is the same data set from the maps library, named differently
 #'

--- a/man/geojsonio.Rd
+++ b/man/geojsonio.Rd
@@ -3,6 +3,7 @@
 \docType{package}
 \name{geojsonio}
 \alias{geojsonio}
+\alias{geojsonio-package}
 \title{\strong{I/O for GeoJSON}}
 \description{
 Convert various data formats to/from GeoJSON or TopoJSON. This
@@ -47,6 +48,15 @@ All of the above functions have methods for various classes, including
 based on the data you give as input.
 }
 
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/ropensci/geojsonio}
+  \item \url{https://docs.ropensci.org/geojsonio/}
+  \item Report bugs at \url{https://github.com/ropensci/geojsonio/issues}
+}
+
+}
 \author{
 Scott Chamberlain
 


### PR DESCRIPTION
From Kurt Hornik this morning:

```
Dear maintainer,

You have file 'geojsonio/man/geojsonio.Rd' with \docType{package},
likely intended as a package overview help file, but without the
appropriate PKGNAME-package \alias as per "Documenting packages" in
R-exts.

This seems to be the consequence of the breaking change

  Using @docType package no longer automatically adds a -package alias.
  Instead document _PACKAGE to get all the defaults for package
  documentation.

in roxygen2 7.0.0 (2019-11-12) having gone unnoticed, see
<https://github.com/r-lib/roxygen2/issues/1491>.

As explained in the issue, to get the desired PKGNAME-package \alias
back, you should either change to the new approach and document the new
special sentinel

  "_PACKAGE"

or manually add

  @aliases geojsonio-package

if remaining with the old approach.

Please fix in your master sources as appropriate, and submit a fixed
version of your package within the next few months.

Best,
-k
```